### PR TITLE
Swap address translators for v4-to-v6 translation

### DIFF
--- a/lib/xlat/rfc7915.rb
+++ b/lib/xlat/rfc7915.rb
@@ -141,8 +141,8 @@ module Xlat
       new_header_buffer.setbyte(7, ipv4_bytes.getbyte(8))
 
       # Source and Destination address
-      cs_delta_a = @source_address_translator.translate_address_to_ipv6(ipv4_bytes[12,4], new_header_buffer, 8) or return return_buffer_ownership()
-      cs_delta_b = @destination_address_translator.translate_address_to_ipv6(ipv4_bytes[16,4], new_header_buffer, 24) or return return_buffer_ownership()
+      cs_delta_a = @destination_address_translator.translate_address_to_ipv6(ipv4_bytes[12,4], new_header_buffer, 8) or return return_buffer_ownership()
+      cs_delta_b = @source_address_translator.translate_address_to_ipv6(ipv4_bytes[16,4], new_header_buffer, 24) or return return_buffer_ownership()
       cs_delta += cs_delta_a + cs_delta_b
 
       if !icmp_payload && ipv4_packet.proto == 1 # icmpv4


### PR DESCRIPTION
This way, a single instance of Xlat::Rfc7915 can correctly translate IPv6 requests into IPv4 and IPv4 responses back into IPv6.

The parameter names now assume the IPv6 network is the "source" side and the IPv4 network is the "destination" side, despite the translator being symmetric. We may have better words for them.