### PR TITLE
Rewrite spec with IO::Buffer

### DIFF
--- a/lib/xlat/common.rb
+++ b/lib/xlat/common.rb
@@ -1,42 +1,6 @@
-# This file is based on the source code available at https://github.com/kazuho/rat under MIT License
-# 
-# Copyright (c) 2022 Kazuho Oku
-# 
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-# 
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
-
-
 module Xlat
   module Common
-    def string_get16be(str, off)
-      str.getbyte(off) * 256 + str.getbyte(off + 1)
-    end
-
-    def string_set16be(str, off, v)
-      # this seems faster than pack-then-replace
-      str.setbyte(off, (v >> 8) & 0xff)
-      str.setbyte(off + 1, v & 0xff)
-    end
-
-    def string_copy16be(str, src, off)
-      str.setbyte(str, off, src.getbyte(off))
-      str.setbyte(str, off+1, src.getbyte(off+1))
-    end
+    module_function
 
     def sum16be(buffer)
       sum = 0
@@ -44,10 +8,6 @@ module Xlat
         sum += x
       end
       sum
-    end
-
-    class << self
-      include Xlat::Common
     end
   end
 end

--- a/spec/rfc7915_spec.rb
+++ b/spec/rfc7915_spec.rb
@@ -3,6 +3,8 @@ require 'ipaddr'
 require 'xlat/rfc7915'
 require 'xlat/protocols/ip'
 
+require_relative 'test_packets'
+
 RSpec.describe Xlat::Rfc7915 do
   module MockAddrTranslator
     def self.translate_address_to_ipv4(ipv6_address,buffer,offset = 0)
@@ -19,7 +21,6 @@ RSpec.describe Xlat::Rfc7915 do
       when IPAddr.new('2001:db8:64::192.0.2.8').to_s
         buffer.copy(IO::Buffer.for(IPAddr.new('192.0.2.8').hton), offset)
         -(0x2001 + 0x0db8 + 0x0064)
-
       end
     end
 
@@ -47,499 +48,14 @@ RSpec.describe Xlat::Rfc7915 do
     end
   end
 
-  TEST_PACKET_IPV4_UDP = [
-    # ipv4
-    %w(45 00),
-    %w(00 1d), # total length (20+8+1=29)
-    %w(c3 98), # identification
-    %w(00 00), # flags
-    %w(40), # ttl
-    %w(11), # protocol
-    %w(33 28), # checksum
-    %w(c0 00 02 07), # src
-    %w(c0 00 02 08), # dst
-
-    # udp
-    %w(c1 5b), # src port
-    %w(00 35), # dst port
-    %w(00 09), # length
-    %w(0b 3b), # checksum
-
-    # payload
-    %w(af),
-  ].flatten.map { _1.to_i(16).chr }.join.b.freeze
-
-  TEST_PACKET_IPV6_UDP = [
-    # ipv6
-    %w(60 00 00 00), # version, qos, flow label
-    %w(00 09), # payload length (8+1=9)
-    %w(11), # next header
-    %w(40), # hop limit
-    %w(20 01 0d b8 00 60 00 00 00 00 00 00 c0 00 02 07), # src
-    %w(20 01 0d b8 00 64 00 00 00 00 00 00 c0 00 02 08), # dst 
-
-    # udp
-    %w(c1 5b), # src port
-    %w(00 35), # dst port
-    %w(00 09), # length
-    %w(af 04), # checksum
-
-    # payload
-    %w(af),
-  ].flatten.map { _1.to_i(16).chr }.join.b.freeze
-
-
-
-  TEST_PACKET_IPV4_TCP = [
-    # ipv4
-    %w(45 00),
-    %w(00 35), # total length (20+32+1=53)
-    %w(c3 98), # identification
-    %w(00 00), # flags
-    %w(40), # ttl
-    %w(06), # protocol
-    %w(33 1b), # checksum
-    %w(c0 00 02 07), # src
-    %w(c0 00 02 08), # dst
-
-    # tcp
-    %w(c1 5b), # src port
-    %w(00 50), # dst port
-    %w(12 34 56 78), # sequence number
-    %w(87 65 43 21), # ack number
-    %w(80), # doffset+rsrvd
-    %w(18), # flags
-    %w(fb fb), # window size
-    %w(b9 cc), # checksum
-    %w(00 00), # urgent pointer
-    %w(01),  # tcp option - nop
-    %w(01),  # tcp option - nop
-    %w(08 0a 77 71 29 f1 76 9a 80 ff),  # tcp option - timestamp
-
-    # payload
-    %w(af),
-  ].flatten.map { _1.to_i(16).chr }.join.b.freeze
-
-  TEST_PACKET_IPV6_TCP = [
-    # ipv6
-    %w(60 00 00 00), # version, qos, flow label
-    %w(00 21), # payload length (32+1=33)
-    %w(06), # next header
-    %w(40), # hop limit
-    %w(20 01 0d b8 00 60 00 00 00 00 00 00 c0 00 02 07), # src
-    %w(20 01 0d b8 00 64 00 00 00 00 00 00 c0 00 02 08), # dst 
-
-    # tcp
-    %w(c1 5b), # src port
-    %w(00 50), # dst port
-    %w(12 34 56 78), # sequence number
-    %w(87 65 43 21), # ack number
-    %w(80), # doffset+rsrvd
-    %w(18), # flags
-    %w(fb fb), # window size
-    %w(5d 96), # checksum
-    %w(00 00), # urgent pointer
-    %w(01),  # tcp option - nop
-    %w(01),  # tcp option - nop
-    %w(08 0a 77 71 29 f1 76 9a 80 ff),  # tcp option - timestamp
-
-    # payload
-    %w(af),
-  ].flatten.map { _1.to_i(16).chr }.join.b.freeze
-
-  TEST_PACKET_IPV4_ICMP_ECHO = [
-    # ipv4
-    %w(45 00),
-    %w(00 1d), # total length (20+8+1=29)
-    %w(c3 98), # identification
-    %w(00 00), # flags
-    %w(40), # ttl
-    %w(01), # protocol
-    %w(33 38), # checksum
-    %w(c0 00 02 07), # src
-    %w(c0 00 02 08), # dst
-
-    # icmp
-    %w(08 00), # type=8,code=0 (echo request)
-    %w(8a fd), # checksum
-    %w(12 34), # identifier
-    %w(ab cd), # sequence number
-
-    # payload
-    %w(af),
-  ].flatten.map { _1.to_i(16).chr }.join.b.freeze
-
-  TEST_PACKET_IPV6_ICMP_ECHO = [
-    # ipv6
-    %w(60 00 00 00), # version, qos, flow label
-    %w(00 09), # payload length (8+1=9)
-    %w(3a), # next header
-    %w(40), # hop limit
-    %w(20 01 0d b8 00 60 00 00 00 00 00 00 c0 00 02 07), # src
-    %w(20 01 0d b8 00 64 00 00 00 00 00 00 c0 00 02 08), # dst 
-
-    # icmp
-    %w(80 00), # type=128,code=0 (echo request)
-    %w(32 73), # checksum
-    %w(12 34), # identifier
-    %w(ab cd), # sequence number
-
-    # payload
-    %w(af),
-  ].flatten.map { _1.to_i(16).chr }.join.b.freeze
-
-  TEST_PACKET_IPV4_ICMP_ECHO_REPLY = [
-    # ipv4
-    %w(45 00),
-    %w(00 1d), # total length (20+8+1=29)
-    %w(c3 98), # identification
-    %w(00 00), # flags
-    %w(40), # ttl
-    %w(01), # protocol
-    %w(33 38), # checksum
-    %w(c0 00 02 07), # src
-    %w(c0 00 02 08), # dst
-
-    # icmp
-    %w(00 00), # type=0, code=0 (echo reply)
-    %w(92 fd), # checksum
-    %w(12 34), # identifier
-    %w(ab cd), # sequence number
-
-    # payload
-    %w(af),
-  ].flatten.map { _1.to_i(16).chr }.join.b.freeze
-
-  TEST_PACKET_IPV6_ICMP_ECHO_REPLY = [
-    # ipv6
-    %w(60 00 00 00), # version, qos, flow label
-    %w(00 09), # payload length (8+1=9)
-    %w(3a), # next header
-    %w(40), # hop limit
-    %w(20 01 0d b8 00 60 00 00 00 00 00 00 c0 00 02 07), # src
-    %w(20 01 0d b8 00 64 00 00 00 00 00 00 c0 00 02 08), # dst
-
-    # icmp
-    %w(81 00), # type=129,code=0 (echo reply)
-    %w(31 73), # checksum
-    %w(12 34), # identifier
-    %w(ab cd), # sequence number
-
-    # payload
-    %w(af),
-  ].flatten.map { _1.to_i(16).chr }.join.b.freeze
-
-  TEST_PACKET_IPV4_ICMP_ADMIN = [
-    # ipv4
-    %w(45 00),
-    %w(00 39), # total length (20+8+20+8+1=57)
-    %w(c3 98), # identification
-    %w(00 00), # flags
-    %w(40), # ttl
-    %w(01), # protocol
-    %w(33 1c), # checksum
-    %w(c0 00 02 07), # src
-    %w(c0 00 02 08), # dst
-
-    # icmp
-    %w(03 0a), # type=3,code=10 (unreachable admin prohibited)
-    %w(10 7c), # checksum
-    %w(00 00 00 00), # unused
-
-    # payload ipv4
-    %w(45 00),
-    %w(00 1d), # total length (20+8+1=29)
-    %w(c3 98), # identification
-    %w(00 00), # flags
-    %w(40), # ttl
-    %w(11), # protocol
-    %w(33 32), # checksum
-    %w(c0 00 02 02), # src
-    %w(c0 00 02 03), # dst
-
-    # payload udp
-    %w(c1 5b), # src port
-    %w(00 35), # dst port
-    %w(00 09), # length
-    %w(7b df), # checksum
-
-    # payload
-    %w(af),
-  ].flatten.map { _1.to_i(16).chr }.join.b.freeze
-
-  TEST_PACKET_IPV6_ICMP_ADMIN = [
-    # ipv6
-    %w(60 00 00 00), # version, qos, flow label
-    %w(00 39), # payload length (8+40+8+1=57)
-    %w(3a), # next header
-    %w(40), # hop limit
-    %w(20 01 0d b8 00 60 00 00 00 00 00 00 c0 00 02 07), # src
-    %w(20 01 0d b8 00 64 00 00 00 00 00 00 c0 00 02 08), # dst 
-
-    # icmp
-    %w(01 01), # type=1,code=1 (unreachable admin prohibited)
-    %w(3c 7b), # checksum
-    %w(00 00 00 00), # unused
-
-    # ipv6
-    %w(60 00 00 00), # version, qos, flow label
-    %w(00 09), # payload length (8+1=9)
-    %w(11), # next header
-    %w(40), # hop limit
-    %w(00 64 ff 9b 00 01 ff fe 00 00 00 00 c0 00 02 02), # src
-    %w(00 64 ff 9b 00 00 00 00 00 00 00 00 c0 00 02 03), # dst 
-
-    # udp
-    %w(c1 5b), # src port
-    %w(00 35), # dst port
-    %w(00 09), # length
-    %w(7b df), # checksum
-
-    # payload
-    %w(af),
-  ].flatten.map { _1.to_i(16).chr }.join.b.freeze
-
-  TEST_PACKET_IPV4_ICMP_MTU = [
-    # ipv4
-    %w(45 00),
-    %w(00 39), # total length (20+8+20+8+1=57)
-    %w(c3 98), # identification
-    %w(00 00), # flags
-    %w(40), # ttl
-    %w(01), # protocol
-    %w(33 1c), # checksum
-    %w(c0 00 02 07), # src
-    %w(c0 00 02 08), # dst
-
-    # icmp
-    %w(03 04), # type=3,code=4 (packet too big)
-    %w(0a ba), # checksum
-    %w(00 00 05 c8), # mtu
-
-    # payload ipv4
-    %w(45 00),
-    %w(00 1d), # total length (20+8+1=29)
-    %w(c3 98), # identification
-    %w(00 00), # flags
-    %w(40), # ttl
-    %w(11), # protocol
-    %w(33 32), # checksum
-    %w(c0 00 02 02), # src
-    %w(c0 00 02 03), # dst
-
-    # payload udp
-    %w(c1 5b), # src port
-    %w(00 35), # dst port
-    %w(00 09), # length
-    %w(7b df), # checksum
-
-    # payload
-    %w(af),
-  ].flatten.map { _1.to_i(16).chr }.join.b.freeze
-
-  TEST_PACKET_IPV6_ICMP_MTU = [
-    # ipv6
-    %w(60 00 00 00), # version, qos, flow label
-    %w(00 39), # payload length (8+40+8+1=57)
-    %w(3a), # next header
-    %w(40), # hop limit
-    %w(20 01 0d b8 00 60 00 00 00 00 00 00 c0 00 02 07), # src
-    %w(20 01 0d b8 00 64 00 00 00 00 00 00 c0 00 02 08), # dst 
-
-    # icmp
-    %w(02 00), # type=2,code=0 (packet too big)
-    %w(35 a0), # checksum
-    %w(ff ff 05 dc), # mtu
-
-    # ipv6
-    %w(60 00 00 00), # version, qos, flow label
-    %w(00 09), # payload length (8+1=9)
-    %w(11), # next header
-    %w(40), # hop limit
-    %w(00 64 ff 9b 00 01 ff fe 00 00 00 00 c0 00 02 02), # src
-    %w(00 64 ff 9b 00 00 00 00 00 00 00 00 c0 00 02 03), # dst 
-
-    # udp
-    %w(c1 5b), # src port
-    %w(00 35), # dst port
-    %w(00 09), # length
-    %w(7b df), # checksum
-
-    # payload
-    %w(af),
-  ].flatten.map { _1.to_i(16).chr }.join.b.freeze
-
-  TEST_PACKET_IPV4_ICMP_POINTER = [
-    # ipv4
-    %w(45 00),
-    %w(00 39), # total length (20+8+20+8+1=57)
-    %w(c3 98), # identification
-    %w(00 00), # flags
-    %w(40), # ttl
-    %w(01), # protocol
-    %w(33 1c), # checksum
-    %w(c0 00 02 07), # src
-    %w(c0 00 02 08), # dst
-
-    # icmp
-    %w(0c 00), # type=12,code=0 (parameter problem)
-    %w(fb 85), # checksum
-    %w(0c 00 00 00), # pointer
-
-    # payload ipv4
-    %w(45 00),
-    %w(00 1d), # total length (20+8+1=29)
-    %w(c3 98), # identification
-    %w(00 00), # flags
-    %w(40), # ttl
-    %w(11), # protocol
-    %w(33 32), # checksum
-    %w(c0 00 02 02), # src
-    %w(c0 00 02 03), # dst
-
-    # payload udp
-    %w(c1 5b), # src port
-    %w(00 35), # dst port
-    %w(00 09), # length
-    %w(7b df), # checksum
-
-    # payload
-    %w(af),
-  ].flatten.map { _1.to_i(16).chr }.join.b.freeze
-
-  TEST_PACKET_IPV6_ICMP_POINTER = [
-    # ipv6
-    %w(60 00 00 00), # version, qos, flow label
-    %w(00 39), # payload length (8+40+8+1=57)
-    %w(3a), # next header
-    %w(40), # hop limit
-    %w(20 01 0d b8 00 60 00 00 00 00 00 00 c0 00 02 07), # src
-    %w(20 01 0d b8 00 64 00 00 00 00 00 00 c0 00 02 08), # dst 
-
-    # icmp
-    %w(04 00), # type=4,code=0 (erroneous header field)
-    %w(39 73), # checksum
-    %w(00 00 00 09), # pointer
-
-    # ipv6
-    %w(60 00 00 00), # version, qos, flow label
-    %w(00 09), # payload length (8+1=9)
-    %w(11), # next header
-    %w(40), # hop limit
-    %w(00 64 ff 9b 00 01 ff fe 00 00 00 00 c0 00 02 02), # src
-    %w(00 64 ff 9b 00 00 00 00 00 00 00 00 c0 00 02 03), # dst 
-
-    # udp
-    %w(c1 5b), # src port
-    %w(00 35), # dst port
-    %w(00 09), # length
-    %w(7b df), # checksum
-
-    # payload
-    %w(af),
-  ].flatten.map { _1.to_i(16).chr }.join.b.freeze
-
-
-
-  TEST_PACKET_IPV6_ETHERIP = [
-    # ipv6
-    %w(60 00 00 00), # version, qos, flow label
-    %w(00 41), # payload length (2+14+40+8+1=65)
-    %w(61), # next header
-    %w(40), # hop limit
-    %w(20 01 0d b8 00 60 00 00 00 00 00 00 c0 00 02 07), # src
-    %w(20 01 0d b8 00 64 00 00 00 00 00 00 c0 00 02 08), # dst 
-
-    # etherip
-    %w(30 00),
-    # ethernet
-    %w(00 15 5d 83 05 09 30 7c 5e 10 75 01 86 dd),
-    # ipv6
-    %w(60 00 00 00), # version, qos, flow label
-    %w(00 09), # payload length (8+1=9)
-    %w(3a), # next header
-    %w(40), # hop limit
-    %w(20 01 0d b8 00 00 00 00 00 00 00 00 00 00 00 0a), # src
-    %w(20 01 0d b8 00 00 00 00 00 00 00 00 00 00 00 0b), # dst 
-    # icmp
-    %w(80 00), # type=128,code=0 (echo request)
-    %w(00 00), # checksum
-    %w(12 34), # identifier
-    %w(ab cd), # sequence number
-    # payload
-    %w(af),
-  ].flatten.map { _1.to_i(16).chr }.join.b.freeze
-  TEST_PACKET_IPV4_ETHERIP = [
-    # ipv4
-    %w(45 00),
-    %w(00 55), # total length (20+2+14+40+8+1=85)
-    %w(c3 98), # identification
-    %w(00 00), # flags
-    %w(40), # ttl
-    %w(61), # protocol
-    %w(32 a0), # checksum
-    %w(c0 00 02 07), # src
-    %w(c0 00 02 08), # dst
-
-    # etherip
-    %w(30 00),
-    # ethernet
-    %w(00 15 5d 83 05 09 30 7c 5e 10 75 01 86 dd),
-    # ipv6
-    %w(60 00 00 00), # version, qos, flow label
-    %w(00 09), # payload length (8+1=9)
-    %w(3a), # next header
-    %w(40), # hop limit
-    %w(20 01 0d b8 00 00 00 00 00 00 00 00 00 00 00 0a), # src
-    %w(20 01 0d b8 00 00 00 00 00 00 00 00 00 00 00 0b), # dst 
-    # icmp
-    %w(80 00), # type=128,code=0 (echo request)
-    %w(00 00), # checksum
-    %w(12 34), # identifier
-    %w(ab cd), # sequence number
-    # payload
-    %w(af),
-  ].flatten.map { _1.to_i(16).chr }.join.b.freeze
-
-  TEST_PACKET_IPV4_ICMP_INCOMPLETE_HDR = [
-    # ipv4
-    %w(45 00),
-    %w(00 18), # total length (20+4=24)
-    %w(c3 98), # identification
-    %w(00 00), # flags
-    %w(40), # ttl
-    %w(01), # protocol
-    %w(33 3d), # checksum
-    %w(c0 00 02 07), # src
-    %w(c0 00 02 08), # dst
-
-    # icmp
-    %w(00 00), # type=0,code=0
-    %w(ff ff), # checksum
-    # incomplete header
-  ].flatten.map { _1.to_i(16).chr }.join.b.freeze
-  TEST_PACKET_IPV6_ICMP_INCOMPLETE_HDR = [
-    # ipv6
-    %w(60 00 00 00), # version, qos, flow label
-    %w(00 04), # payload length (4)
-    %w(3a), # next header
-    %w(40), # hop limit
-    %w(20 01 0d b8 00 60 00 00 00 00 00 00 c0 00 02 07), # src
-    %w(20 01 0d b8 00 64 00 00 00 00 00 00 c0 00 02 08), # dst
-
-    # icmp
-    %w(00 00), # type=0,code=0
-    %w(1f 7b), # checksum
-    # incomplete header
-  ].flatten.map { _1.to_i(16).chr }.join.b.freeze
 
   def expect_packet_equal(version, expected_packet_, output, checksum: nil)
     expected_packet = expected_packet_.dup
 
-    expected_packet.setbyte(version == 4 ? 8 : 7,0x3f) # TTL
+    expected_packet.set_value(:U8, version == 4 ? 8 : 7, 0x3f) # TTL
     if version == 4
-      cs = Xlat::Common.string_get16be(expected_packet, 10)
-      Xlat::Common.string_set16be(expected_packet, 10, Xlat::Protocols::Ip.checksum_adjust(cs, -1 * 256)) # TTL
+      cs = expected_packet.get_value(:U16, 10)
+      expected_packet.set_value(:U16, 10, Xlat::Protocols::Ip.checksum_adjust(cs, -1 * 256)) # TTL
     end
 
     hdrlen = version == 4 ? 20 : 40
@@ -549,8 +65,8 @@ RSpec.describe Xlat::Rfc7915 do
     #p l4expected: expected_packet[hdrlen..].chars.map { _1.ord.to_s(16).rjust(2,'0') }.join(' ')
     #p l4actual__: [output[1]].join.chars.map { _1.ord.to_s(16).rjust(2,'0') }.join(' ')
 
-    expect(output[0].get_string).to eq(expected_packet[0...hdrlen])
-    expect(output[1..].map(&:get_string).join).to eq(expected_packet[hdrlen..])
+    expect(output[0].get_string).to eq(expected_packet.get_string(0, hdrlen))
+    expect(output[1..].map(&:get_string).join).to eq(expected_packet.get_string(hdrlen))
     assert_checksum(output[0]) if version == 4
   end
 
@@ -563,7 +79,7 @@ RSpec.describe Xlat::Rfc7915 do
       version == 4 ? output[0].get_string(16,4) : output[0].get_string(24,16), # l3 dst addr
       "\x00".b,
       protocol, # l3 protocol field
-      "\x00\x00".b.tap { Xlat::Common.string_set16be(_1, 0, data.size) }, # l4 size
+      [data.size].pack('n'), # l4 size
     ]
     case
     when version == 4 && protocol == "\x01".b # ICMPv4 lack pseudo-header
@@ -575,12 +91,10 @@ RSpec.describe Xlat::Rfc7915 do
       pseudo_header,
       data || "".b,
     ].join.b
-    #p bytes.chars.map { _1.ord.to_s(16).rjust(2,'0') }.join(' ')
-    assert_checksum(bytes)
+    assert_checksum(IO::Buffer.for(bytes))
   end
 
   def assert_checksum(bytes)
-    bytes = IO::Buffer.for(bytes) if bytes.is_a?(String)
     cs = Xlat::Protocols::Ip.checksum(bytes)
     cs = 0 if cs == 0xffff
     expect(cs).to eq(0)
@@ -593,22 +107,22 @@ RSpec.describe Xlat::Rfc7915 do
   end
 
   describe "meta" do
-    self.class.ancestors.flat_map(&:constants).grep(/TEST_PACKET_/).uniq.each do |test_packet_const_name|
+    TestPackets.constants.grep(/TEST_PACKET_/).uniq.each do |test_packet_const_name|
       version = test_packet_const_name.to_s.include?('IPV4') ? 4 : 6
       l4cksum = test_packet_const_name.to_s.match?(/_TRUE_|DNS|ICMP|TCP|UDP/i)
-      bytes = const_get(test_packet_const_name)
+      bytes = TestPackets.const_get(test_packet_const_name)
       describe test_packet_const_name do
         let(:output) do
           hdrlen = (version == 4 ? 20 : 40)
           [
-            IO::Buffer.for(bytes[0...hdrlen]),
-            IO::Buffer.for(bytes[hdrlen..]),
+            bytes.slice(0, hdrlen),
+            bytes.slice(hdrlen),
           ]
         end
 
         it "has a correct l3 checksum (ipv4)" do
           assert_checksum(output[0]) if version == 4
-        end if version == 4 
+        end if version == 4
 
         it "has a correct l4 checksum" do
           assert_l4_checksum(version)
@@ -619,63 +133,63 @@ RSpec.describe Xlat::Rfc7915 do
 
   describe "#translate_to_ipv4" do
     context "with udp" do
-      let!(:output) { translator.translate_to_ipv4(Xlat::Protocols::Ip.parse(buffer_from_string(TEST_PACKET_IPV6_UDP.dup))) }
+      let!(:output) { translator.translate_to_ipv4(Xlat::Protocols::Ip.parse(TestPackets::TEST_PACKET_IPV6_UDP.dup)) }
 
       it "translates into ipv4" do
-        expect_packet_equal(4, TEST_PACKET_IPV4_UDP, output)
+        expect_packet_equal(4, TestPackets::TEST_PACKET_IPV4_UDP, output)
         assert_l4_checksum(4)
       end
     end
 
     context "with tcp" do
-      let!(:output) { translator.translate_to_ipv4(Xlat::Protocols::Ip.parse(buffer_from_string(TEST_PACKET_IPV6_TCP.dup))) }
+      let!(:output) { translator.translate_to_ipv4(Xlat::Protocols::Ip.parse(TestPackets::TEST_PACKET_IPV6_TCP.dup)) }
 
       it "translates into ipv4" do
-        expect_packet_equal(4, TEST_PACKET_IPV4_TCP, output)
+        expect_packet_equal(4, TestPackets::TEST_PACKET_IPV4_TCP, output)
         assert_l4_checksum(4)
       end
     end
 
     context "with icmp echo" do
-      let!(:output) { translator.translate_to_ipv4(Xlat::Protocols::Ip.parse(buffer_from_string(TEST_PACKET_IPV6_ICMP_ECHO.dup))) }
+      let!(:output) { translator.translate_to_ipv4(Xlat::Protocols::Ip.parse(TestPackets::TEST_PACKET_IPV6_ICMP_ECHO.dup)) }
 
       it "translates into ipv4" do
-        expect_packet_equal(4, TEST_PACKET_IPV4_ICMP_ECHO, output)
+        expect_packet_equal(4, TestPackets::TEST_PACKET_IPV4_ICMP_ECHO, output)
         assert_l4_checksum(4)
       end
     end
 
     context "with icmp echo reply" do
-      let!(:output) { translator.translate_to_ipv4(Xlat::Protocols::Ip.parse(buffer_from_string(TEST_PACKET_IPV6_ICMP_ECHO_REPLY.dup))) }
+      let!(:output) { translator.translate_to_ipv4(Xlat::Protocols::Ip.parse(TestPackets::TEST_PACKET_IPV6_ICMP_ECHO_REPLY.dup)) }
 
       it "translates into ipv4" do
-        expect_packet_equal(4, TEST_PACKET_IPV4_ICMP_ECHO_REPLY, output)
+        expect_packet_equal(4, TestPackets::TEST_PACKET_IPV4_ICMP_ECHO_REPLY, output)
         assert_l4_checksum(4)
       end
     end
 
     context "with icmp payload" do
-      let!(:output) { translator.translate_to_ipv4(Xlat::Protocols::Ip.parse(buffer_from_string(TEST_PACKET_IPV6_ICMP_ADMIN.dup))) }
+      let!(:output) { translator.translate_to_ipv4(Xlat::Protocols::Ip.parse(TestPackets::TEST_PACKET_IPV6_ICMP_ADMIN.dup)) }
 
       it "translates into ipv4" do
-        expect_packet_equal(4, TEST_PACKET_IPV4_ICMP_ADMIN, output)
+        expect_packet_equal(4, TestPackets::TEST_PACKET_IPV4_ICMP_ADMIN, output)
         assert_l4_checksum(4)
       end
     end
 
     context "with icmp payload + RFC 4884" do
       let!(:output) do
-        ipv6 = TEST_PACKET_IPV6_ICMP_ADMIN.dup
-        ipv6.setbyte(44,49) # rfc4884 length
-        Xlat::Common.string_set16be(ipv6,42,Xlat::Protocols::Ip.checksum_adjust(Xlat::Common.string_get16be(ipv6,42), 49 << 8))
+        ipv6 = TestPackets::TEST_PACKET_IPV6_ICMP_ADMIN.dup
+        ipv6.set_value(:U8, 44, 49) # rfc4884 length
+        ipv6.set_value(:U16, 42, Xlat::Protocols::Ip.checksum_adjust(ipv6.get_value(:U16, 42), 49 << 8))
 
-        translator.translate_to_ipv4(Xlat::Protocols::Ip.parse(buffer_from_string(ipv6)))
+        translator.translate_to_ipv4(Xlat::Protocols::Ip.parse(ipv6))
       end
 
       it "translates into ipv4" do
-        ipv4 = TEST_PACKET_IPV4_ICMP_ADMIN.dup
-        ipv4.setbyte(25,29) # rfc4884 length
-        Xlat::Common.string_set16be(ipv4,22,Xlat::Protocols::Ip.checksum_adjust(Xlat::Common.string_get16be(ipv4,22), 29))
+        ipv4 = TestPackets::TEST_PACKET_IPV4_ICMP_ADMIN.dup
+        ipv4.set_value(:U8, 25, 29) # rfc4884 length
+        ipv4.set_value(:U16, 22, Xlat::Protocols::Ip.checksum_adjust(ipv4.get_value(:U16, 22), 29))
 
         expect_packet_equal(4, ipv4, output)
         assert_l4_checksum(4)
@@ -683,89 +197,89 @@ RSpec.describe Xlat::Rfc7915 do
     end
 
     context "with icmp mtu" do
-      let!(:output) { translator.translate_to_ipv4(Xlat::Protocols::Ip.parse(buffer_from_string(TEST_PACKET_IPV6_ICMP_MTU.dup))) }
+      let!(:output) { translator.translate_to_ipv4(Xlat::Protocols::Ip.parse(TestPackets::TEST_PACKET_IPV6_ICMP_MTU.dup)) }
 
       it "translates into ipv4" do
-        expect_packet_equal(4, TEST_PACKET_IPV4_ICMP_MTU, output)
+        expect_packet_equal(4, TestPackets::TEST_PACKET_IPV4_ICMP_MTU, output)
         assert_l4_checksum(4)
       end
     end
 
     context "with icmp err header field" do
-      let!(:output) { translator.translate_to_ipv4(Xlat::Protocols::Ip.parse(buffer_from_string(TEST_PACKET_IPV6_ICMP_POINTER.dup))) }
+      let!(:output) { translator.translate_to_ipv4(Xlat::Protocols::Ip.parse(TestPackets::TEST_PACKET_IPV6_ICMP_POINTER.dup)) }
 
       it "translates into ipv4" do
-        expect_packet_equal(4, TEST_PACKET_IPV4_ICMP_POINTER, output)
+        expect_packet_equal(4, TestPackets::TEST_PACKET_IPV4_ICMP_POINTER, output)
         assert_l4_checksum(4)
       end
     end
 
     context "with unknown protocol" do
-      let!(:output) { translator.translate_to_ipv4(Xlat::Protocols::Ip.parse(buffer_from_string(TEST_PACKET_IPV6_ETHERIP.dup))) }
+      let!(:output) { translator.translate_to_ipv4(Xlat::Protocols::Ip.parse(TestPackets::TEST_PACKET_IPV6_ETHERIP.dup)) }
 
       it "translates into ipv4" do
-        expect_packet_equal(4, TEST_PACKET_IPV4_ETHERIP, output)
+        expect_packet_equal(4, TestPackets::TEST_PACKET_IPV4_ETHERIP, output)
       end
     end
   end
 
   describe "#translate_to_ipv6" do
     context "with udp" do
-      let!(:output) { translator.translate_to_ipv6(Xlat::Protocols::Ip.parse(buffer_from_string(TEST_PACKET_IPV4_UDP.dup))) }
+      let!(:output) { translator.translate_to_ipv6(Xlat::Protocols::Ip.parse(TestPackets::TEST_PACKET_IPV4_UDP.dup)) }
 
       it "translates into ipv6" do
-        expect_packet_equal(6, TEST_PACKET_IPV6_UDP, output)
+        expect_packet_equal(6, TestPackets::TEST_PACKET_IPV6_UDP, output)
       end
     end
 
     context "with tcp" do
-      let!(:output) { translator.translate_to_ipv6(Xlat::Protocols::Ip.parse(buffer_from_string(TEST_PACKET_IPV4_TCP.dup))) }
+      let!(:output) { translator.translate_to_ipv6(Xlat::Protocols::Ip.parse(TestPackets::TEST_PACKET_IPV4_TCP.dup)) }
 
       it "translates into ipv6" do
-        expect_packet_equal(6, TEST_PACKET_IPV6_TCP, output)
+        expect_packet_equal(6, TestPackets::TEST_PACKET_IPV6_TCP, output)
       end
     end
 
     context "with icmp echo" do
-      let!(:output) { translator.translate_to_ipv6(Xlat::Protocols::Ip.parse(buffer_from_string(TEST_PACKET_IPV4_ICMP_ECHO.dup))) }
+      let!(:output) { translator.translate_to_ipv6(Xlat::Protocols::Ip.parse(TestPackets::TEST_PACKET_IPV4_ICMP_ECHO.dup)) }
 
       it "translates into ipv6" do
-        expect_packet_equal(6, TEST_PACKET_IPV6_ICMP_ECHO, output)
+        expect_packet_equal(6, TestPackets::TEST_PACKET_IPV6_ICMP_ECHO, output)
         assert_l4_checksum(6)
       end
     end
 
     context "with icmp echo reply" do
-      let!(:output) { translator.translate_to_ipv6(Xlat::Protocols::Ip.parse(buffer_from_string(TEST_PACKET_IPV4_ICMP_ECHO_REPLY.dup))) }
+      let!(:output) { translator.translate_to_ipv6(Xlat::Protocols::Ip.parse(TestPackets::TEST_PACKET_IPV4_ICMP_ECHO_REPLY.dup)) }
 
       it "translates into ipv6" do
-        expect_packet_equal(6, TEST_PACKET_IPV6_ICMP_ECHO_REPLY, output)
+        expect_packet_equal(6, TestPackets::TEST_PACKET_IPV6_ICMP_ECHO_REPLY, output)
         assert_l4_checksum(6)
       end
     end
 
     context "with icmp payload" do
-      let!(:output) { translator.translate_to_ipv6(Xlat::Protocols::Ip.parse(buffer_from_string(TEST_PACKET_IPV4_ICMP_ADMIN.dup))) }
+      let!(:output) { translator.translate_to_ipv6(Xlat::Protocols::Ip.parse(TestPackets::TEST_PACKET_IPV4_ICMP_ADMIN.dup)) }
 
       it "translates into ipv6" do
-        expect_packet_equal(6, TEST_PACKET_IPV6_ICMP_ADMIN, output)
+        expect_packet_equal(6, TestPackets::TEST_PACKET_IPV6_ICMP_ADMIN, output)
         assert_l4_checksum(6)
       end
     end
 
     context "with icmp payload + RFC 4884" do
       let!(:output) do
-        ipv4 = TEST_PACKET_IPV4_ICMP_ADMIN.dup
-        ipv4.setbyte(25,29) # rfc4884 length
-        Xlat::Common.string_set16be(ipv4,22,Xlat::Protocols::Ip.checksum_adjust(Xlat::Common.string_get16be(ipv4,22), 29))
+        ipv4 = TestPackets::TEST_PACKET_IPV4_ICMP_ADMIN.dup
+        ipv4.set_value(:U8, 25, 29) # rfc4884 length
+        ipv4.set_value(:U16, 22, Xlat::Protocols::Ip.checksum_adjust(ipv4.get_value(:U16 ,22), 29))
 
-        translator.translate_to_ipv6(Xlat::Protocols::Ip.parse(buffer_from_string(ipv4)))
+        translator.translate_to_ipv6(Xlat::Protocols::Ip.parse(ipv4))
       end
 
       it "translates into ipv6" do
-        ipv6 = TEST_PACKET_IPV6_ICMP_ADMIN.dup
-        ipv6.setbyte(44,49) # rfc4884 length
-        Xlat::Common.string_set16be(ipv6,42,Xlat::Protocols::Ip.checksum_adjust(Xlat::Common.string_get16be(ipv6,42), 49 << 8))
+        ipv6 = TestPackets::TEST_PACKET_IPV6_ICMP_ADMIN.dup
+        ipv6.set_value(:U8, 44, 49) # rfc4884 length
+        ipv6.set_value(:U16, 42, Xlat::Protocols::Ip.checksum_adjust(ipv6.get_value(:U16, 42), 49 << 8))
 
         expect_packet_equal(6, ipv6, output)
         assert_l4_checksum(6)
@@ -773,14 +287,13 @@ RSpec.describe Xlat::Rfc7915 do
     end
 
     context "with icmp mtu" do
-      let!(:output) { translator.translate_to_ipv6(Xlat::Protocols::Ip.parse(buffer_from_string(TEST_PACKET_IPV4_ICMP_MTU.dup))) }
+      let!(:output) { translator.translate_to_ipv6(Xlat::Protocols::Ip.parse(TestPackets::TEST_PACKET_IPV4_ICMP_MTU.dup)) }
 
       it "translates into ipv6" do
-        ipv6 = TEST_PACKET_IPV6_ICMP_MTU.dup
+        ipv6 = TestPackets::TEST_PACKET_IPV6_ICMP_MTU.dup
         # clear first 2 octets from MTU field (32-bit number) contained in TEST_PACKET_IPV6_ICMP_MTU
         # no checksum adjust as -0xffff keep checksum
-        ipv6.setbyte(44,0)
-        ipv6.setbyte(45,0)
+        ipv6.set_value(:U16, 44, 0)
 
         expect_packet_equal(6, ipv6, output)
         assert_l4_checksum(6)
@@ -788,12 +301,12 @@ RSpec.describe Xlat::Rfc7915 do
     end
 
     context "with icmp err header field" do
-      let!(:output) { translator.translate_to_ipv6(Xlat::Protocols::Ip.parse(buffer_from_string(TEST_PACKET_IPV4_ICMP_POINTER.dup))) }
+      let!(:output) { translator.translate_to_ipv6(Xlat::Protocols::Ip.parse(TestPackets::TEST_PACKET_IPV4_ICMP_POINTER.dup)) }
 
       it "translates into ipv6" do
-        ipv6 = TEST_PACKET_IPV6_ICMP_POINTER.dup
-        ipv6.setbyte(47,0x08) # pointer=8
-        Xlat::Common.string_set16be(ipv6,42,Xlat::Protocols::Ip.checksum_adjust(Xlat::Common.string_get16be(ipv6,42), -1))
+        ipv6 = TestPackets::TEST_PACKET_IPV6_ICMP_POINTER.dup
+        ipv6.set_value(:U8, 47, 0x08) # pointer=8
+        ipv6.set_value(:U16, 42, Xlat::Protocols::Ip.checksum_adjust(ipv6.get_value(:U16, 42), -1))
 
         expect_packet_equal(6, ipv6, output)
         assert_l4_checksum(6)
@@ -801,15 +314,15 @@ RSpec.describe Xlat::Rfc7915 do
     end
 
     context "with unknown protocol" do
-      let!(:output) { translator.translate_to_ipv6(Xlat::Protocols::Ip.parse(buffer_from_string(TEST_PACKET_IPV4_ETHERIP.dup))) }
+      let!(:output) { translator.translate_to_ipv6(Xlat::Protocols::Ip.parse(TestPackets::TEST_PACKET_IPV4_ETHERIP.dup)) }
 
       it "translates into ipv6" do
-        expect_packet_equal(6, TEST_PACKET_IPV6_ETHERIP, output)
+        expect_packet_equal(6, TestPackets::TEST_PACKET_IPV6_ETHERIP, output)
       end
     end
 
     context "with ICMP incomplete header" do
-      let!(:output) {  translator.translate_to_ipv6(Xlat::Protocols::Ip.parse(buffer_from_string(TEST_PACKET_IPV4_ICMP_INCOMPLETE_HDR.dup))) }
+      let!(:output) {  translator.translate_to_ipv6(Xlat::Protocols::Ip.parse(TestPackets::TEST_PACKET_IPV4_ICMP_INCOMPLETE_HDR.dup)) }
 
       it "is discarded without error" do
         expect(output).to be_nil
@@ -817,7 +330,7 @@ RSpec.describe Xlat::Rfc7915 do
     end
 
     context "with ICMP6 incomplete header" do
-      let!(:output) {  translator.translate_to_ipv4(Xlat::Protocols::Ip.parse(buffer_from_string(TEST_PACKET_IPV6_ICMP_INCOMPLETE_HDR.dup))) }
+      let!(:output) {  translator.translate_to_ipv4(Xlat::Protocols::Ip.parse(TestPackets::TEST_PACKET_IPV6_ICMP_INCOMPLETE_HDR.dup)) }
 
       it "is discarded without error" do
         expect(output).to be_nil

--- a/spec/test_packets.rb
+++ b/spec/test_packets.rb
@@ -1,0 +1,491 @@
+module TestPackets
+  class << self
+    def buffer(ary)
+      IO::Buffer.for(ary.flatten.map { _1.to_i(16).chr }.join.b.freeze)
+    end
+  end
+
+  TEST_PACKET_IPV4_UDP = buffer [
+    # ipv4
+    %w(45 00),
+    %w(00 1d), # total length (20+8+1=29)
+    %w(c3 98), # identification
+    %w(00 00), # flags
+    %w(40), # ttl
+    %w(11), # protocol
+    %w(33 28), # checksum
+    %w(c0 00 02 07), # src
+    %w(c0 00 02 08), # dst
+
+    # udp
+    %w(c1 5b), # src port
+    %w(00 35), # dst port
+    %w(00 09), # length
+    %w(0b 3b), # checksum
+
+    # payload
+    %w(af),
+  ]
+
+  TEST_PACKET_IPV6_UDP = buffer [
+    # ipv6
+    %w(60 00 00 00), # version, qos, flow label
+    %w(00 09), # payload length (8+1=9)
+    %w(11), # next header
+    %w(40), # hop limit
+    %w(20 01 0d b8 00 60 00 00 00 00 00 00 c0 00 02 07), # src
+    %w(20 01 0d b8 00 64 00 00 00 00 00 00 c0 00 02 08), # dst
+
+    # udp
+    %w(c1 5b), # src port
+    %w(00 35), # dst port
+    %w(00 09), # length
+    %w(af 04), # checksum
+
+    # payload
+    %w(af),
+  ]
+
+  TEST_PACKET_IPV4_TCP = buffer [
+    # ipv4
+    %w(45 00),
+    %w(00 35), # total length (20+32+1=53)
+    %w(c3 98), # identification
+    %w(00 00), # flags
+    %w(40), # ttl
+    %w(06), # protocol
+    %w(33 1b), # checksum
+    %w(c0 00 02 07), # src
+    %w(c0 00 02 08), # dst
+
+    # tcp
+    %w(c1 5b), # src port
+    %w(00 50), # dst port
+    %w(12 34 56 78), # sequence number
+    %w(87 65 43 21), # ack number
+    %w(80), # doffset+rsrvd
+    %w(18), # flags
+    %w(fb fb), # window size
+    %w(b9 cc), # checksum
+    %w(00 00), # urgent pointer
+    %w(01),  # tcp option - nop
+    %w(01),  # tcp option - nop
+    %w(08 0a 77 71 29 f1 76 9a 80 ff),  # tcp option - timestamp
+
+    # payload
+    %w(af),
+  ]
+
+  TEST_PACKET_IPV6_TCP = buffer [
+    # ipv6
+    %w(60 00 00 00), # version, qos, flow label
+    %w(00 21), # payload length (32+1=33)
+    %w(06), # next header
+    %w(40), # hop limit
+    %w(20 01 0d b8 00 60 00 00 00 00 00 00 c0 00 02 07), # src
+    %w(20 01 0d b8 00 64 00 00 00 00 00 00 c0 00 02 08), # dst
+
+    # tcp
+    %w(c1 5b), # src port
+    %w(00 50), # dst port
+    %w(12 34 56 78), # sequence number
+    %w(87 65 43 21), # ack number
+    %w(80), # doffset+rsrvd
+    %w(18), # flags
+    %w(fb fb), # window size
+    %w(5d 96), # checksum
+    %w(00 00), # urgent pointer
+    %w(01),  # tcp option - nop
+    %w(01),  # tcp option - nop
+    %w(08 0a 77 71 29 f1 76 9a 80 ff),  # tcp option - timestamp
+
+    # payload
+    %w(af),
+  ]
+
+  TEST_PACKET_IPV4_ICMP_ECHO = buffer [
+    # ipv4
+    %w(45 00),
+    %w(00 1d), # total length (20+8+1=29)
+    %w(c3 98), # identification
+    %w(00 00), # flags
+    %w(40), # ttl
+    %w(01), # protocol
+    %w(33 38), # checksum
+    %w(c0 00 02 07), # src
+    %w(c0 00 02 08), # dst
+
+    # icmp
+    %w(08 00), # type=8,code=0 (echo request)
+    %w(8a fd), # checksum
+    %w(12 34), # identifier
+    %w(ab cd), # sequence number
+
+    # payload
+    %w(af),
+  ]
+
+  TEST_PACKET_IPV6_ICMP_ECHO = buffer [
+    # ipv6
+    %w(60 00 00 00), # version, qos, flow label
+    %w(00 09), # payload length (8+1=9)
+    %w(3a), # next header
+    %w(40), # hop limit
+    %w(20 01 0d b8 00 60 00 00 00 00 00 00 c0 00 02 07), # src
+    %w(20 01 0d b8 00 64 00 00 00 00 00 00 c0 00 02 08), # dst
+
+    # icmp
+    %w(80 00), # type=128,code=0 (echo request)
+    %w(32 73), # checksum
+    %w(12 34), # identifier
+    %w(ab cd), # sequence number
+
+    # payload
+    %w(af),
+  ]
+
+  TEST_PACKET_IPV4_ICMP_ECHO_REPLY = buffer [
+    # ipv4
+    %w(45 00),
+    %w(00 1d), # total length (20+8+1=29)
+    %w(c3 98), # identification
+    %w(00 00), # flags
+    %w(40), # ttl
+    %w(01), # protocol
+    %w(33 38), # checksum
+    %w(c0 00 02 07), # src
+    %w(c0 00 02 08), # dst
+
+    # icmp
+    %w(00 00), # type=0, code=0 (echo reply)
+    %w(92 fd), # checksum
+    %w(12 34), # identifier
+    %w(ab cd), # sequence number
+
+    # payload
+    %w(af),
+  ]
+
+  TEST_PACKET_IPV6_ICMP_ECHO_REPLY = buffer [
+    # ipv6
+    %w(60 00 00 00), # version, qos, flow label
+    %w(00 09), # payload length (8+1=9)
+    %w(3a), # next header
+    %w(40), # hop limit
+    %w(20 01 0d b8 00 60 00 00 00 00 00 00 c0 00 02 07), # src
+    %w(20 01 0d b8 00 64 00 00 00 00 00 00 c0 00 02 08), # dst
+
+    # icmp
+    %w(81 00), # type=129,code=0 (echo reply)
+    %w(31 73), # checksum
+    %w(12 34), # identifier
+    %w(ab cd), # sequence number
+
+    # payload
+    %w(af),
+  ]
+
+  TEST_PACKET_IPV4_ICMP_ADMIN = buffer [
+    # ipv4
+    %w(45 00),
+    %w(00 39), # total length (20+8+20+8+1=57)
+    %w(c3 98), # identification
+    %w(00 00), # flags
+    %w(40), # ttl
+    %w(01), # protocol
+    %w(33 1c), # checksum
+    %w(c0 00 02 07), # src
+    %w(c0 00 02 08), # dst
+
+    # icmp
+    %w(03 0a), # type=3,code=10 (unreachable admin prohibited)
+    %w(10 7c), # checksum
+    %w(00 00 00 00), # unused
+
+    # payload ipv4
+    %w(45 00),
+    %w(00 1d), # total length (20+8+1=29)
+    %w(c3 98), # identification
+    %w(00 00), # flags
+    %w(40), # ttl
+    %w(11), # protocol
+    %w(33 32), # checksum
+    %w(c0 00 02 02), # src
+    %w(c0 00 02 03), # dst
+
+    # payload udp
+    %w(c1 5b), # src port
+    %w(00 35), # dst port
+    %w(00 09), # length
+    %w(7b df), # checksum
+
+    # payload
+    %w(af),
+  ]
+
+  TEST_PACKET_IPV6_ICMP_ADMIN = buffer [
+    # ipv6
+    %w(60 00 00 00), # version, qos, flow label
+    %w(00 39), # payload length (8+40+8+1=57)
+    %w(3a), # next header
+    %w(40), # hop limit
+    %w(20 01 0d b8 00 60 00 00 00 00 00 00 c0 00 02 07), # src
+    %w(20 01 0d b8 00 64 00 00 00 00 00 00 c0 00 02 08), # dst
+
+    # icmp
+    %w(01 01), # type=1,code=1 (unreachable admin prohibited)
+    %w(3c 7b), # checksum
+    %w(00 00 00 00), # unused
+
+    # ipv6
+    %w(60 00 00 00), # version, qos, flow label
+    %w(00 09), # payload length (8+1=9)
+    %w(11), # next header
+    %w(40), # hop limit
+    %w(00 64 ff 9b 00 01 ff fe 00 00 00 00 c0 00 02 02), # src
+    %w(00 64 ff 9b 00 00 00 00 00 00 00 00 c0 00 02 03), # dst
+
+    # udp
+    %w(c1 5b), # src port
+    %w(00 35), # dst port
+    %w(00 09), # length
+    %w(7b df), # checksum
+
+    # payload
+    %w(af),
+  ]
+
+  TEST_PACKET_IPV4_ICMP_MTU = buffer [
+    # ipv4
+    %w(45 00),
+    %w(00 39), # total length (20+8+20+8+1=57)
+    %w(c3 98), # identification
+    %w(00 00), # flags
+    %w(40), # ttl
+    %w(01), # protocol
+    %w(33 1c), # checksum
+    %w(c0 00 02 07), # src
+    %w(c0 00 02 08), # dst
+
+    # icmp
+    %w(03 04), # type=3,code=4 (packet too big)
+    %w(0a ba), # checksum
+    %w(00 00 05 c8), # mtu
+
+    # payload ipv4
+    %w(45 00),
+    %w(00 1d), # total length (20+8+1=29)
+    %w(c3 98), # identification
+    %w(00 00), # flags
+    %w(40), # ttl
+    %w(11), # protocol
+    %w(33 32), # checksum
+    %w(c0 00 02 02), # src
+    %w(c0 00 02 03), # dst
+
+    # payload udp
+    %w(c1 5b), # src port
+    %w(00 35), # dst port
+    %w(00 09), # length
+    %w(7b df), # checksum
+
+    # payload
+    %w(af),
+  ]
+
+  TEST_PACKET_IPV6_ICMP_MTU = buffer [
+    # ipv6
+    %w(60 00 00 00), # version, qos, flow label
+    %w(00 39), # payload length (8+40+8+1=57)
+    %w(3a), # next header
+    %w(40), # hop limit
+    %w(20 01 0d b8 00 60 00 00 00 00 00 00 c0 00 02 07), # src
+    %w(20 01 0d b8 00 64 00 00 00 00 00 00 c0 00 02 08), # dst
+
+    # icmp
+    %w(02 00), # type=2,code=0 (packet too big)
+    %w(35 a0), # checksum
+    %w(ff ff 05 dc), # mtu
+
+    # ipv6
+    %w(60 00 00 00), # version, qos, flow label
+    %w(00 09), # payload length (8+1=9)
+    %w(11), # next header
+    %w(40), # hop limit
+    %w(00 64 ff 9b 00 01 ff fe 00 00 00 00 c0 00 02 02), # src
+    %w(00 64 ff 9b 00 00 00 00 00 00 00 00 c0 00 02 03), # dst
+
+    # udp
+    %w(c1 5b), # src port
+    %w(00 35), # dst port
+    %w(00 09), # length
+    %w(7b df), # checksum
+
+    # payload
+    %w(af),
+  ]
+
+  TEST_PACKET_IPV4_ICMP_POINTER = buffer [
+    # ipv4
+    %w(45 00),
+    %w(00 39), # total length (20+8+20+8+1=57)
+    %w(c3 98), # identification
+    %w(00 00), # flags
+    %w(40), # ttl
+    %w(01), # protocol
+    %w(33 1c), # checksum
+    %w(c0 00 02 07), # src
+    %w(c0 00 02 08), # dst
+
+    # icmp
+    %w(0c 00), # type=12,code=0 (parameter problem)
+    %w(fb 85), # checksum
+    %w(0c 00 00 00), # pointer
+
+    # payload ipv4
+    %w(45 00),
+    %w(00 1d), # total length (20+8+1=29)
+    %w(c3 98), # identification
+    %w(00 00), # flags
+    %w(40), # ttl
+    %w(11), # protocol
+    %w(33 32), # checksum
+    %w(c0 00 02 02), # src
+    %w(c0 00 02 03), # dst
+
+    # payload udp
+    %w(c1 5b), # src port
+    %w(00 35), # dst port
+    %w(00 09), # length
+    %w(7b df), # checksum
+
+    # payload
+    %w(af),
+  ]
+
+  TEST_PACKET_IPV6_ICMP_POINTER = buffer [
+    # ipv6
+    %w(60 00 00 00), # version, qos, flow label
+    %w(00 39), # payload length (8+40+8+1=57)
+    %w(3a), # next header
+    %w(40), # hop limit
+    %w(20 01 0d b8 00 60 00 00 00 00 00 00 c0 00 02 07), # src
+    %w(20 01 0d b8 00 64 00 00 00 00 00 00 c0 00 02 08), # dst
+
+    # icmp
+    %w(04 00), # type=4,code=0 (erroneous header field)
+    %w(39 73), # checksum
+    %w(00 00 00 09), # pointer
+
+    # ipv6
+    %w(60 00 00 00), # version, qos, flow label
+    %w(00 09), # payload length (8+1=9)
+    %w(11), # next header
+    %w(40), # hop limit
+    %w(00 64 ff 9b 00 01 ff fe 00 00 00 00 c0 00 02 02), # src
+    %w(00 64 ff 9b 00 00 00 00 00 00 00 00 c0 00 02 03), # dst
+
+    # udp
+    %w(c1 5b), # src port
+    %w(00 35), # dst port
+    %w(00 09), # length
+    %w(7b df), # checksum
+
+    # payload
+    %w(af),
+  ]
+
+  TEST_PACKET_IPV6_ETHERIP = buffer [
+    # ipv6
+    %w(60 00 00 00), # version, qos, flow label
+    %w(00 41), # payload length (2+14+40+8+1=65)
+    %w(61), # next header
+    %w(40), # hop limit
+    %w(20 01 0d b8 00 60 00 00 00 00 00 00 c0 00 02 07), # src
+    %w(20 01 0d b8 00 64 00 00 00 00 00 00 c0 00 02 08), # dst
+
+    # etherip
+    %w(30 00),
+    # ethernet
+    %w(00 15 5d 83 05 09 30 7c 5e 10 75 01 86 dd),
+    # ipv6
+    %w(60 00 00 00), # version, qos, flow label
+    %w(00 09), # payload length (8+1=9)
+    %w(3a), # next header
+    %w(40), # hop limit
+    %w(20 01 0d b8 00 00 00 00 00 00 00 00 00 00 00 0a), # src
+    %w(20 01 0d b8 00 00 00 00 00 00 00 00 00 00 00 0b), # dst
+    # icmp
+    %w(80 00), # type=128,code=0 (echo request)
+    %w(00 00), # checksum
+    %w(12 34), # identifier
+    %w(ab cd), # sequence number
+    # payload
+    %w(af),
+  ]
+
+  TEST_PACKET_IPV4_ETHERIP = buffer [
+    # ipv4
+    %w(45 00),
+    %w(00 55), # total length (20+2+14+40+8+1=85)
+    %w(c3 98), # identification
+    %w(00 00), # flags
+    %w(40), # ttl
+    %w(61), # protocol
+    %w(32 a0), # checksum
+    %w(c0 00 02 07), # src
+    %w(c0 00 02 08), # dst
+
+    # etherip
+    %w(30 00),
+    # ethernet
+    %w(00 15 5d 83 05 09 30 7c 5e 10 75 01 86 dd),
+    # ipv6
+    %w(60 00 00 00), # version, qos, flow label
+    %w(00 09), # payload length (8+1=9)
+    %w(3a), # next header
+    %w(40), # hop limit
+    %w(20 01 0d b8 00 00 00 00 00 00 00 00 00 00 00 0a), # src
+    %w(20 01 0d b8 00 00 00 00 00 00 00 00 00 00 00 0b), # dst
+    # icmp
+    %w(80 00), # type=128,code=0 (echo request)
+    %w(00 00), # checksum
+    %w(12 34), # identifier
+    %w(ab cd), # sequence number
+    # payload
+    %w(af),
+  ]
+
+  TEST_PACKET_IPV4_ICMP_INCOMPLETE_HDR = buffer [
+    # ipv4
+    %w(45 00),
+    %w(00 18), # total length (20+4=24)
+    %w(c3 98), # identification
+    %w(00 00), # flags
+    %w(40), # ttl
+    %w(01), # protocol
+    %w(33 3d), # checksum
+    %w(c0 00 02 07), # src
+    %w(c0 00 02 08), # dst
+
+    # icmp
+    %w(00 00), # type=0,code=0
+    %w(ff ff), # checksum
+    # incomplete header
+  ]
+
+  TEST_PACKET_IPV6_ICMP_INCOMPLETE_HDR = buffer [
+    # ipv6
+    %w(60 00 00 00), # version, qos, flow label
+    %w(00 04), # payload length (4)
+    %w(3a), # next header
+    %w(40), # hop limit
+    %w(20 01 0d b8 00 60 00 00 00 00 00 00 c0 00 02 07), # src
+    %w(20 01 0d b8 00 64 00 00 00 00 00 00 c0 00 02 08), # dst
+
+    # icmp
+    %w(00 00), # type=0,code=0
+    %w(1f 7b), # checksum
+    # incomplete header
+  ]
+end


### PR DESCRIPTION
Following up #5, the specs are rewritten in more IO::Buffer way.