### PR TITLE
Generate description for test packets used in spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 .rspec_status
 
 *.so
+*.pcap

--- a/Gemfile
+++ b/Gemfile
@@ -9,3 +9,5 @@ gem "rake", "~> 13.0"
 gem "rake-compiler", "~> 1.2"
 gem "rspec", "~> 3.0"
 gem "pf2", "0.6.0"
+
+gem "rexml"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,6 +16,7 @@ GEM
     rake-compiler (1.2.7)
       rake
     rb_sys (0.9.102)
+    rexml (3.3.7)
     rspec (3.12.0)
       rspec-core (~> 3.12.0)
       rspec-expectations (~> 3.12.0)
@@ -38,6 +39,7 @@ DEPENDENCIES
   pf2 (= 0.6.0)
   rake (~> 13.0)
   rake-compiler (~> 1.2)
+  rexml
   rspec (~> 3.0)
   xlat!
 

--- a/Rakefile
+++ b/Rakefile
@@ -14,3 +14,64 @@ Rake::ExtensionTask.new("xlat/io_buffer_ext",
 end
 
 task spec: :compile
+
+
+directory 'doc'
+
+file 'doc/test_packets.xml' => ['doc', 'spec/test_packets.rb', 'Rakefile'] do |f|
+  require 'open3'
+  require 'pathname'
+  require 'rexml'
+  require 'xlat/pcap'
+  require_relative './spec/test_packets'
+
+  packets = TestPackets.constants.filter_map {|k|
+    val = TestPackets.const_get(k)
+    next unless val.is_a?(IO::Buffer)
+
+    {
+      name: k,
+      source_location: TestPackets.const_source_location(k).yield_self {|path, line|
+        [Pathname(path).relative_path_from(__dir__), line]
+      },
+      value: val,
+    }
+  }.sort_by { _1[:source_location] }
+
+  pdml = Open3.popen2(*%W[tshark -n -r- -Tpdml]) do |stdin, stdout, *|
+    pcap = Xlat::Pcap.new(stdin)
+    packets.each do |h|
+      pcap.write(h[:value], ts: Time.at(0))
+    end
+    stdin.close
+
+    xml = REXML::Document.new(stdout)
+
+    xml.get_elements('//packet').zip(packets) do |e_packet, pkt|
+      comment = "#{pkt[:name]} at #{pkt[:source_location].join(?:)}"
+
+      e_packet.unshift(
+        REXML::Element.new('proto').tap {|e_field|
+          e_field.add_attribute('name', 'pkt_comment')
+          e_field.add_attribute('pos', 0)
+          e_field.add_attribute('size', 0)
+          e_field.add_attribute('showname', comment)
+        },
+      )
+    end
+
+    File.write(f.name, xml.to_s)
+  end
+end
+
+file 'doc/pdml2html.xsl' => ['doc'] do |f|
+  require 'net/http'
+  require 'uri'
+
+  uri = URI.parse('https://gitlab.com/wireshark/wireshark/-/raw/v4.4.0/resources/share/doc/wireshark/pdml2html.xsl').freeze
+
+  File.write(f.name, Net::HTTP.get(uri))
+end
+
+desc 'Generate documents'
+task gendoc: %w[doc/test_packets.xml doc/pdml2html.xsl]

--- a/lib/xlat/pcap.rb
+++ b/lib/xlat/pcap.rb
@@ -1,0 +1,48 @@
+# https://datatracker.ietf.org/doc/draft-ietf-opsawg-pcap/04/
+
+module Xlat
+  class Pcap
+    attr_reader :io, :snap_len
+
+    def initialize(io, snap_len: 0xffff)
+      @io = io
+      @snap_len = snap_len
+
+      write_header
+    end
+
+    MAGIC = 0xA1B23C4D  # nanosec timestamp
+    MAJOR = 2
+    MINOR = 4
+    LINKTYPE_RAW = 101  # raw IP
+
+    private def write_header
+      h = IO::Buffer.new(24)
+      h.set_values(%i[u32 u16 u16 u32 u32 u32 u32], 0, [
+        MAGIC,
+        MAJOR, MINOR,
+        0,
+        0,
+        @snap_len,
+        LINKTYPE_RAW,
+      ])
+
+      h.write(@io)
+    end
+
+    def write(packet, ts: Time.now)
+      caplen = [packet.size, @snap_len].min
+
+      h = IO::Buffer.new(16)
+      h.set_values(%i[u32 u32 u32 u32], 0, [
+        ts.to_i,
+        ts.nsec,
+        caplen,
+        packet.size,
+      ])
+
+      h.write(@io)
+      packet.write(@io, caplen)
+    end
+  end
+end


### PR DESCRIPTION
Using Wireshark, generate packet descriptions to see if they have the intended structures.