### PR TITLE
protocols/ip: Track L4 length

### DIFF
--- a/lib/xlat/protocols/ip/ipv4.rb
+++ b/lib/xlat/protocols/ip/ipv4.rb
@@ -65,13 +65,15 @@ module Xlat
           bytes = packet.bytes
           offset = packet.bytes_offset
 
-          return false if bytes.get_value(:U8, offset) != 0x45
+          return false if bytes.get_value(:U8, offset) != 0x45  # TODO: handle IPv4 options
           # tos?
-          # totlen?
+
+          total_length = bytes.get_value(:U16, offset + 2)
+          return false if total_length < 20
+          return false unless packet.set_l4_region(20, total_length - 20)
+
           # ignore identification
           return false if bytes.get_value(:U16, offset + 6) & 0xbfff != 0 # ignore fragments
-
-          packet.l4_start = 20
 
           proto = bytes.get_value(:U8, offset + 9)
           packet.proto = proto

--- a/lib/xlat/protocols/ip/ipv6.rb
+++ b/lib/xlat/protocols/ip/ipv6.rb
@@ -72,13 +72,13 @@ module Xlat
 
           return false if bytes.size < 40
 
+          return false unless packet.set_l4_region(40, bytes.get_value(:U16, offset + 4))
           proto = bytes.get_value(:U8, offset + 6)
 
           # drop packets containing IPv6 extensions (RFC 7045 grudgingly acknowledges existence of such middleboxes)
           return false if EXTENSIONS[proto]
 
           packet.proto = proto
-          packet.l4_start = 40
 
           true
         end

--- a/lib/xlat/rfc7915.rb
+++ b/lib/xlat/rfc7915.rb
@@ -110,7 +110,7 @@ module Xlat
       if icmp_output
         @output.concat(icmp_output)
       else
-        @output << ipv4_packet.l4_bytes.slice(ipv4_packet.l4_bytes_offset)
+        @output << ipv4_packet.l4_bytes.slice(ipv4_packet.l4_bytes_offset, ipv4_packet.l4_bytes_length)
       end
       @output
     end
@@ -166,7 +166,7 @@ module Xlat
       if icmp_output
         @output.concat(icmp_output)
       else
-        @output << ipv6_packet.l4_bytes.slice(ipv6_packet.l4_bytes_offset)
+        @output << ipv6_packet.l4_bytes.slice(ipv6_packet.l4_bytes_offset, ipv6_packet.l4_bytes_length)
       end
       @output
     end

--- a/spec/rfc7915_spec.rb
+++ b/spec/rfc7915_spec.rb
@@ -177,6 +177,15 @@ RSpec.describe Xlat::Rfc7915 do
       end
     end
 
+    context "with icmp truncated payload" do
+      let!(:output) { translator.translate_to_ipv4(Xlat::Protocols::Ip.parse(TestPackets::TEST_PACKET_IPV6_ICMP_ADMIN_TRUNC.dup)) }
+
+      it "translates into ipv4" do
+        expect_packet_equal(4, TestPackets::TEST_PACKET_IPV4_ICMP_ADMIN_TRUNC, output)
+        assert_l4_checksum(4)
+      end
+    end
+
     context "with icmp payload + RFC 4884" do
       let!(:output) do
         ipv6 = TestPackets::TEST_PACKET_IPV6_ICMP_ADMIN.dup
@@ -263,6 +272,15 @@ RSpec.describe Xlat::Rfc7915 do
 
       it "translates into ipv6" do
         expect_packet_equal(6, TestPackets::TEST_PACKET_IPV6_ICMP_ADMIN, output)
+        assert_l4_checksum(6)
+      end
+    end
+
+    context "with truncated icmp payload" do
+      let!(:output) { translator.translate_to_ipv6(Xlat::Protocols::Ip.parse(TestPackets::TEST_PACKET_IPV4_ICMP_ADMIN_TRUNC.dup)) }
+
+      it "translates into ipv6" do
+        expect_packet_equal(6, TestPackets::TEST_PACKET_IPV6_ICMP_ADMIN_TRUNC, output)
         assert_l4_checksum(6)
       end
     end

--- a/spec/test_packets.rb
+++ b/spec/test_packets.rb
@@ -255,6 +255,80 @@ module TestPackets
     %w(af),
   ]
 
+  TEST_PACKET_IPV4_ICMP_ADMIN_TRUNC = buffer [
+    # ipv4
+    %w(45 00),
+    %w(00 39), # total length (20+8+20+8+1=57)
+    %w(c3 98), # identification
+    %w(00 00), # flags
+    %w(40), # ttl
+    %w(01), # protocol
+    %w(33 1c), # checksum
+    %w(c0 00 02 07), # src
+    %w(c0 00 02 08), # dst
+
+    # icmp
+    %w(03 0a), # type=3,code=10 (unreachable admin prohibited)
+    %w(8c 54), # checksum
+    %w(00 00 00 00), # unused
+
+    # payload ipv4
+    %w(45 00),
+    %w(00 24), # total length (20+8+8=36)
+    %w(c3 98), # identification
+    %w(00 00), # flags
+    %w(40), # ttl
+    %w(11), # protocol
+    %w(33 2b), # checksum
+    %w(c0 00 02 02), # src
+    %w(c0 00 02 03), # dst
+
+    # payload udp
+    %w(c1 5b), # src port
+    %w(00 35), # dst port
+    %w(00 10), # length
+    %w(ff ff), # checksum
+
+    # payload
+    %w(af),
+
+    # truncated (7 octets)
+  ]
+
+  TEST_PACKET_IPV6_ICMP_ADMIN_TRUNC = buffer [
+    # ipv6
+    %w(60 00 00 00), # version, qos, flow label
+    %w(00 39), # payload length (8+40+8+1=57)
+    %w(3a), # next header
+    %w(40), # hop limit
+    %w(20 01 0d b8 00 60 00 00 00 00 00 00 c0 00 02 07), # src
+    %w(20 01 0d b8 00 64 00 00 00 00 00 00 c0 00 02 08), # dst
+
+    # icmp
+    %w(01 01), # type=1,code=1 (unreachable admin prohibited)
+    %w(b8 4c), # checksum
+    %w(00 00 00 00), # unused
+
+    # ipv6
+    %w(60 00 00 00), # version, qos, flow label
+    %w(00 10), # payload length (8+8=16)
+    %w(11), # next header
+    %w(40), # hop limit
+    %w(00 64 ff 9b 00 01 ff fe 00 00 00 00 c0 00 02 02), # src
+    %w(00 64 ff 9b 00 00 00 00 00 00 00 00 c0 00 02 03), # dst
+
+    # udp
+    %w(c1 5b), # src port
+    %w(00 35), # dst port
+    %w(00 10), # length
+    %w(ff ff), # checksum
+
+    # payload
+    %w(af),
+
+    # truncated (7 octets)
+  ]
+
   TEST_PACKET_IPV4_ICMP_MTU = buffer [
     # ipv4
     %w(45 00),


### PR DESCRIPTION
For RFC4884-style ICMP payloads, the end of IP datagram does not coincide with that of the outer datagram (ICMP), so we need to track its length.