### PR TITLE
Fix RFC4884-style ICMP message handling

### DIFF
--- a/lib/xlat/runner.rb
+++ b/lib/xlat/runner.rb
@@ -9,7 +9,8 @@ module Xlat
     end
 
     def run
-      buf = IO::Buffer.new(@adapter.mtu)
+      mtu = @adapter.mtu
+      buf = IO::Buffer.new(mtu)
       parser = Protocols::Ip.new
 
       loop do
@@ -23,9 +24,9 @@ module Xlat
 
         case
         when pkt.version == Protocols::Ip::Ipv4
-          output = @translator.translate_to_ipv6(pkt)
+          output = @translator.translate_to_ipv6(pkt, mtu)
         when pkt.version == Protocols::Ip::Ipv6
-          output = @translator.translate_to_ipv4(pkt)
+          output = @translator.translate_to_ipv4(pkt, mtu)
         else
           fail 'unknown IP version'
         end

--- a/spec/rfc7915_spec.rb
+++ b/spec/rfc7915_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe Xlat::Rfc7915 do
 
   describe "#translate_to_ipv4" do
     context "with udp" do
-      let!(:output) { translator.translate_to_ipv4(Xlat::Protocols::Ip.parse(TestPackets::TEST_PACKET_IPV6_UDP.dup)) }
+      let!(:output) { translator.translate_to_ipv4(Xlat::Protocols::Ip.parse(TestPackets::TEST_PACKET_IPV6_UDP.dup), 1500) }
 
       it "translates into ipv4" do
         expect_packet_equal(4, TestPackets::TEST_PACKET_IPV4_UDP, output)
@@ -142,7 +142,7 @@ RSpec.describe Xlat::Rfc7915 do
     end
 
     context "with tcp" do
-      let!(:output) { translator.translate_to_ipv4(Xlat::Protocols::Ip.parse(TestPackets::TEST_PACKET_IPV6_TCP.dup)) }
+      let!(:output) { translator.translate_to_ipv4(Xlat::Protocols::Ip.parse(TestPackets::TEST_PACKET_IPV6_TCP.dup), 1500) }
 
       it "translates into ipv4" do
         expect_packet_equal(4, TestPackets::TEST_PACKET_IPV4_TCP, output)
@@ -151,7 +151,7 @@ RSpec.describe Xlat::Rfc7915 do
     end
 
     context "with icmp echo" do
-      let!(:output) { translator.translate_to_ipv4(Xlat::Protocols::Ip.parse(TestPackets::TEST_PACKET_IPV6_ICMP_ECHO.dup)) }
+      let!(:output) { translator.translate_to_ipv4(Xlat::Protocols::Ip.parse(TestPackets::TEST_PACKET_IPV6_ICMP_ECHO.dup), 1500) }
 
       it "translates into ipv4" do
         expect_packet_equal(4, TestPackets::TEST_PACKET_IPV4_ICMP_ECHO, output)
@@ -160,7 +160,7 @@ RSpec.describe Xlat::Rfc7915 do
     end
 
     context "with icmp echo reply" do
-      let!(:output) { translator.translate_to_ipv4(Xlat::Protocols::Ip.parse(TestPackets::TEST_PACKET_IPV6_ICMP_ECHO_REPLY.dup)) }
+      let!(:output) { translator.translate_to_ipv4(Xlat::Protocols::Ip.parse(TestPackets::TEST_PACKET_IPV6_ICMP_ECHO_REPLY.dup), 1500) }
 
       it "translates into ipv4" do
         expect_packet_equal(4, TestPackets::TEST_PACKET_IPV4_ICMP_ECHO_REPLY, output)
@@ -169,7 +169,7 @@ RSpec.describe Xlat::Rfc7915 do
     end
 
     context "with icmp payload" do
-      let!(:output) { translator.translate_to_ipv4(Xlat::Protocols::Ip.parse(TestPackets::TEST_PACKET_IPV6_ICMP_ADMIN.dup)) }
+      let!(:output) { translator.translate_to_ipv4(Xlat::Protocols::Ip.parse(TestPackets::TEST_PACKET_IPV6_ICMP_ADMIN.dup), 1500) }
 
       it "translates into ipv4" do
         expect_packet_equal(4, TestPackets::TEST_PACKET_IPV4_ICMP_ADMIN, output)
@@ -178,7 +178,7 @@ RSpec.describe Xlat::Rfc7915 do
     end
 
     context "with icmp truncated payload" do
-      let!(:output) { translator.translate_to_ipv4(Xlat::Protocols::Ip.parse(TestPackets::TEST_PACKET_IPV6_ICMP_ADMIN_TRUNC.dup)) }
+      let!(:output) { translator.translate_to_ipv4(Xlat::Protocols::Ip.parse(TestPackets::TEST_PACKET_IPV6_ICMP_ADMIN_TRUNC.dup), 1500) }
 
       it "translates into ipv4" do
         expect_packet_equal(4, TestPackets::TEST_PACKET_IPV4_ICMP_ADMIN_TRUNC, output)
@@ -187,26 +187,16 @@ RSpec.describe Xlat::Rfc7915 do
     end
 
     context "with icmp payload + RFC 4884" do
-      let!(:output) do
-        ipv6 = TestPackets::TEST_PACKET_IPV6_ICMP_ADMIN.dup
-        ipv6.set_value(:U8, 44, 49) # rfc4884 length
-        ipv6.set_value(:U16, 42, Xlat::Protocols::Ip.checksum_adjust(ipv6.get_value(:U16, 42), 49 << 8))
-
-        translator.translate_to_ipv4(Xlat::Protocols::Ip.parse(ipv6))
-      end
+      let!(:output) { translator.translate_to_ipv4(Xlat::Protocols::Ip.parse(TestPackets::TEST_PACKET_IPV6_ICMP_ADMIN_RFC4884.dup), 1500) }
 
       it "translates into ipv4" do
-        ipv4 = TestPackets::TEST_PACKET_IPV4_ICMP_ADMIN.dup
-        ipv4.set_value(:U8, 25, 29) # rfc4884 length
-        ipv4.set_value(:U16, 22, Xlat::Protocols::Ip.checksum_adjust(ipv4.get_value(:U16, 22), 29))
-
-        expect_packet_equal(4, ipv4, output)
+        expect_packet_equal(4, TestPackets::TEST_PACKET_IPV4_ICMP_ADMIN_RFC4884, output)
         assert_l4_checksum(4)
       end
     end
 
     context "with icmp mtu" do
-      let!(:output) { translator.translate_to_ipv4(Xlat::Protocols::Ip.parse(TestPackets::TEST_PACKET_IPV6_ICMP_MTU.dup)) }
+      let!(:output) { translator.translate_to_ipv4(Xlat::Protocols::Ip.parse(TestPackets::TEST_PACKET_IPV6_ICMP_MTU.dup), 1500) }
 
       it "translates into ipv4" do
         expect_packet_equal(4, TestPackets::TEST_PACKET_IPV4_ICMP_MTU, output)
@@ -215,7 +205,7 @@ RSpec.describe Xlat::Rfc7915 do
     end
 
     context "with icmp err header field" do
-      let!(:output) { translator.translate_to_ipv4(Xlat::Protocols::Ip.parse(TestPackets::TEST_PACKET_IPV6_ICMP_POINTER.dup)) }
+      let!(:output) { translator.translate_to_ipv4(Xlat::Protocols::Ip.parse(TestPackets::TEST_PACKET_IPV6_ICMP_POINTER.dup), 1500) }
 
       it "translates into ipv4" do
         expect_packet_equal(4, TestPackets::TEST_PACKET_IPV4_ICMP_POINTER, output)
@@ -224,7 +214,7 @@ RSpec.describe Xlat::Rfc7915 do
     end
 
     context "with unknown protocol" do
-      let!(:output) { translator.translate_to_ipv4(Xlat::Protocols::Ip.parse(TestPackets::TEST_PACKET_IPV6_ETHERIP.dup)) }
+      let!(:output) { translator.translate_to_ipv4(Xlat::Protocols::Ip.parse(TestPackets::TEST_PACKET_IPV6_ETHERIP.dup), 1500) }
 
       it "translates into ipv4" do
         expect_packet_equal(4, TestPackets::TEST_PACKET_IPV4_ETHERIP, output)
@@ -232,7 +222,7 @@ RSpec.describe Xlat::Rfc7915 do
     end
 
     context "with ICMP6 incomplete header" do
-      let!(:output) {  translator.translate_to_ipv4(Xlat::Protocols::Ip.parse(TestPackets::TEST_PACKET_IPV6_ICMP_INCOMPLETE_HDR.dup)) }
+      let!(:output) {  translator.translate_to_ipv4(Xlat::Protocols::Ip.parse(TestPackets::TEST_PACKET_IPV6_ICMP_INCOMPLETE_HDR.dup), 1500) }
 
       it "is discarded without error" do
         expect(output).to be_nil
@@ -242,7 +232,7 @@ RSpec.describe Xlat::Rfc7915 do
 
   describe "#translate_to_ipv6" do
     context "with udp" do
-      let!(:output) { translator.translate_to_ipv6(Xlat::Protocols::Ip.parse(TestPackets::TEST_PACKET_IPV4_UDP.dup)) }
+      let!(:output) { translator.translate_to_ipv6(Xlat::Protocols::Ip.parse(TestPackets::TEST_PACKET_IPV4_UDP.dup), 1500) }
 
       it "translates into ipv6" do
         expect_packet_equal(6, TestPackets::TEST_PACKET_IPV6_UDP, output)
@@ -250,7 +240,7 @@ RSpec.describe Xlat::Rfc7915 do
     end
 
     context "with tcp" do
-      let!(:output) { translator.translate_to_ipv6(Xlat::Protocols::Ip.parse(TestPackets::TEST_PACKET_IPV4_TCP.dup)) }
+      let!(:output) { translator.translate_to_ipv6(Xlat::Protocols::Ip.parse(TestPackets::TEST_PACKET_IPV4_TCP.dup), 1500) }
 
       it "translates into ipv6" do
         expect_packet_equal(6, TestPackets::TEST_PACKET_IPV6_TCP, output)
@@ -258,7 +248,7 @@ RSpec.describe Xlat::Rfc7915 do
     end
 
     context "with icmp echo" do
-      let!(:output) { translator.translate_to_ipv6(Xlat::Protocols::Ip.parse(TestPackets::TEST_PACKET_IPV4_ICMP_ECHO.dup)) }
+      let!(:output) { translator.translate_to_ipv6(Xlat::Protocols::Ip.parse(TestPackets::TEST_PACKET_IPV4_ICMP_ECHO.dup), 1500) }
 
       it "translates into ipv6" do
         expect_packet_equal(6, TestPackets::TEST_PACKET_IPV6_ICMP_ECHO, output)
@@ -267,7 +257,7 @@ RSpec.describe Xlat::Rfc7915 do
     end
 
     context "with icmp echo reply" do
-      let!(:output) { translator.translate_to_ipv6(Xlat::Protocols::Ip.parse(TestPackets::TEST_PACKET_IPV4_ICMP_ECHO_REPLY.dup)) }
+      let!(:output) { translator.translate_to_ipv6(Xlat::Protocols::Ip.parse(TestPackets::TEST_PACKET_IPV4_ICMP_ECHO_REPLY.dup), 1500) }
 
       it "translates into ipv6" do
         expect_packet_equal(6, TestPackets::TEST_PACKET_IPV6_ICMP_ECHO_REPLY, output)
@@ -276,7 +266,7 @@ RSpec.describe Xlat::Rfc7915 do
     end
 
     context "with icmp payload" do
-      let!(:output) { translator.translate_to_ipv6(Xlat::Protocols::Ip.parse(TestPackets::TEST_PACKET_IPV4_ICMP_ADMIN.dup)) }
+      let!(:output) { translator.translate_to_ipv6(Xlat::Protocols::Ip.parse(TestPackets::TEST_PACKET_IPV4_ICMP_ADMIN.dup), 1500) }
 
       it "translates into ipv6" do
         expect_packet_equal(6, TestPackets::TEST_PACKET_IPV6_ICMP_ADMIN, output)
@@ -285,7 +275,7 @@ RSpec.describe Xlat::Rfc7915 do
     end
 
     context "with truncated icmp payload" do
-      let!(:output) { translator.translate_to_ipv6(Xlat::Protocols::Ip.parse(TestPackets::TEST_PACKET_IPV4_ICMP_ADMIN_TRUNC.dup)) }
+      let!(:output) { translator.translate_to_ipv6(Xlat::Protocols::Ip.parse(TestPackets::TEST_PACKET_IPV4_ICMP_ADMIN_TRUNC.dup), 1500) }
 
       it "translates into ipv6" do
         expect_packet_equal(6, TestPackets::TEST_PACKET_IPV6_ICMP_ADMIN_TRUNC, output)
@@ -294,26 +284,16 @@ RSpec.describe Xlat::Rfc7915 do
     end
 
     context "with icmp payload + RFC 4884" do
-      let!(:output) do
-        ipv4 = TestPackets::TEST_PACKET_IPV4_ICMP_ADMIN.dup
-        ipv4.set_value(:U8, 25, 29) # rfc4884 length
-        ipv4.set_value(:U16, 22, Xlat::Protocols::Ip.checksum_adjust(ipv4.get_value(:U16 ,22), 29))
-
-        translator.translate_to_ipv6(Xlat::Protocols::Ip.parse(ipv4))
-      end
+      let!(:output) { translator.translate_to_ipv6(Xlat::Protocols::Ip.parse(TestPackets::TEST_PACKET_IPV4_ICMP_ADMIN_RFC4884.dup), 1500) }
 
       it "translates into ipv6" do
-        ipv6 = TestPackets::TEST_PACKET_IPV6_ICMP_ADMIN.dup
-        ipv6.set_value(:U8, 44, 49) # rfc4884 length
-        ipv6.set_value(:U16, 42, Xlat::Protocols::Ip.checksum_adjust(ipv6.get_value(:U16, 42), 49 << 8))
-
-        expect_packet_equal(6, ipv6, output)
+        expect_packet_equal(6, TestPackets::TEST_PACKET_IPV6_ICMP_ADMIN_RFC4884, output)
         assert_l4_checksum(6)
       end
     end
 
     context "with icmp mtu" do
-      let!(:output) { translator.translate_to_ipv6(Xlat::Protocols::Ip.parse(TestPackets::TEST_PACKET_IPV4_ICMP_MTU.dup)) }
+      let!(:output) { translator.translate_to_ipv6(Xlat::Protocols::Ip.parse(TestPackets::TEST_PACKET_IPV4_ICMP_MTU.dup), 1500) }
 
       it "translates into ipv6" do
         ipv6 = TestPackets::TEST_PACKET_IPV6_ICMP_MTU.dup
@@ -327,7 +307,7 @@ RSpec.describe Xlat::Rfc7915 do
     end
 
     context "with icmp err header field" do
-      let!(:output) { translator.translate_to_ipv6(Xlat::Protocols::Ip.parse(TestPackets::TEST_PACKET_IPV4_ICMP_POINTER.dup)) }
+      let!(:output) { translator.translate_to_ipv6(Xlat::Protocols::Ip.parse(TestPackets::TEST_PACKET_IPV4_ICMP_POINTER.dup), 1500) }
 
       it "translates into ipv6" do
         ipv6 = TestPackets::TEST_PACKET_IPV6_ICMP_POINTER.dup
@@ -340,7 +320,7 @@ RSpec.describe Xlat::Rfc7915 do
     end
 
     context "with unknown protocol" do
-      let!(:output) { translator.translate_to_ipv6(Xlat::Protocols::Ip.parse(TestPackets::TEST_PACKET_IPV4_ETHERIP.dup)) }
+      let!(:output) { translator.translate_to_ipv6(Xlat::Protocols::Ip.parse(TestPackets::TEST_PACKET_IPV4_ETHERIP.dup), 1500) }
 
       it "translates into ipv6" do
         expect_packet_equal(6, TestPackets::TEST_PACKET_IPV6_ETHERIP, output)
@@ -348,7 +328,7 @@ RSpec.describe Xlat::Rfc7915 do
     end
 
     context "with ICMP incomplete header" do
-      let!(:output) {  translator.translate_to_ipv6(Xlat::Protocols::Ip.parse(TestPackets::TEST_PACKET_IPV4_ICMP_INCOMPLETE_HDR.dup)) }
+      let!(:output) {  translator.translate_to_ipv6(Xlat::Protocols::Ip.parse(TestPackets::TEST_PACKET_IPV4_ICMP_INCOMPLETE_HDR.dup), 1500) }
 
       it "is discarded without error" do
         expect(output).to be_nil

--- a/spec/test_packets.rb
+++ b/spec/test_packets.rb
@@ -469,6 +469,103 @@ module TestPackets
     %w(af),
   ]
 
+  TEST_PACKET_IPV4_ICMP_ADMIN_RFC4884 = buffer [
+    # ipv4
+    %w(45 00),
+    %w(00 a8), # total length (20+8+20+8+100+4+8=168)
+    %w(c3 98), # identification
+    %w(00 00), # flags
+    %w(40), # ttl
+    %w(01), # protocol
+    %w(32 ad), # checksum
+    %w(c0 00 02 07), # src
+    %w(c0 00 02 08), # dst
+
+    # icmp
+    %w(03 0a), # type=3,code=10 (unreachable admin prohibited)
+    %w(80 f6), # checksum
+    %w(00), # unused
+    %w(20), # original datagram length (measured in 32 bits)
+    %w(00 00), # unused
+
+    # payload ipv4
+    %w(45 00),
+    %w(00 1d), # total length (20+8+1=29)
+    %w(c3 98), # identification
+    %w(00 00), # flags
+    %w(40), # ttl
+    %w(11), # protocol
+    %w(33 32), # checksum
+    %w(c0 00 02 02), # src
+    %w(c0 00 02 03), # dst
+
+    # payload udp
+    %w(c1 5b), # src port
+    %w(00 35), # dst port
+    %w(00 09), # length
+    %w(0b 45), # checksum
+
+    # payload
+    %w(af),
+
+    # padding to 128 bytes
+    %w(00) * (128-20-8-1),
+
+    # icmp extension header
+    %w(20 00), # version
+    %w(78 2f), # checksum
+
+    # icmp extension object (private use)
+    %w(00 08), # length
+    %w(ff 1b), # class / sub-type
+    %w(12 34 56 78), # payload
+  ]
+
+  TEST_PACKET_IPV6_ICMP_ADMIN_RFC4884 = buffer [
+    # ipv6
+    %w(60 00 00 00), # version, qos, flow label
+    %w(00 4c), # payload length (8+40+8+8+4+8=76)
+    %w(3a), # next header
+    %w(40), # hop limit
+    %w(20 01 0d b8 00 60 00 00 00 00 00 00 c0 00 02 07), # src
+    %w(20 01 0d b8 00 64 00 00 00 00 00 00 c0 00 02 08), # dst
+
+    # icmp
+    %w(01 01), # type=1,code=1 (unreachable admin prohibited)
+    %w(a6 02), # checksum
+    %w(07), # original datagram length (measured in 64 bits)
+    %w(00 00 00), # unused
+
+    # ipv6
+    %w(60 00 00 00), # version, qos, flow label
+    %w(00 09), # payload length (8+1=9)
+    %w(11), # next header
+    %w(40), # hop limit
+    %w(00 64 ff 9b 00 01 ff fe 00 00 00 00 c0 00 02 02), # src
+    %w(00 64 ff 9b 00 00 00 00 00 00 00 00 c0 00 02 03), # dst
+
+    # udp
+    %w(c1 5b), # src port
+    %w(00 35), # dst port
+    %w(00 09), # length
+    %w(0b 45), # checksum
+
+    # payload
+    %w(af),
+
+    # padding to 64bit boundary
+    %w(00) * 7,
+
+    # icmp extension header
+    %w(20 00), # version
+    %w(78 2f), # checksum
+
+    # icmp extension object (private use)
+    %w(00 08), # length
+    %w(ff 1b), # class / sub-type
+    %w(12 34 56 78), # payload
+   ]
+
   TEST_PACKET_IPV6_ETHERIP = buffer [
     # ipv6
     %w(60 00 00 00), # version, qos, flow label


### PR DESCRIPTION
RFC4884 extends ICMP/ICMPv6 to include ICMP Extension Structure after the original datagram field in ICMP/ICMPv6 errors.

To translate between ICMP and ICMPv6 messages, the original datagram is translated into the corresponding IP version, and then the ICMP Extension Structure should be appended after proper zero padding.