### PR TITLE
Ignore IPv4 Options

### DIFF
--- a/lib/xlat/protocols/ip/ipv6.rb
+++ b/lib/xlat/protocols/ip/ipv6.rb
@@ -66,7 +66,7 @@ module Xlat
           end
         end
 
-        def self.parse(packet)
+        def self.parse(packet, _b0)
           bytes = packet.bytes
           offset = packet.bytes_offset
 

--- a/lib/xlat/rfc7915.rb
+++ b/lib/xlat/rfc7915.rb
@@ -65,8 +65,7 @@ module Xlat
       # FIXME: ToS ignored
 
       # Total Length = copy from IPv6; may be updated in later step
-      ipv6_length = ipv6_bytes.get_value(:U16, ipv6_bytes_offset + 4)
-      ipv4_length = ipv6_length + 20
+      ipv4_length = ipv6_packet.l4_length + 20
       # not considering as a checksum delta because upper layer packet length doesn't take this into account; cs_delta += ipv6_length - ipv4_length
       new_header_buffer.set_value(:U16, 2, ipv4_length)
 
@@ -85,6 +84,7 @@ module Xlat
       cs_delta += cs_delta_a + cs_delta_b
 
       # TODO: DF bit
+      # TODO: discard if expired source route option is present
 
       if !icmp_payload && ipv6_packet.proto == 58 # icmpv6
         icmp_result, icmp_output = translate_icmpv6_to_icmpv4(ipv6_packet, new_header_buffer, max_length - 20)
@@ -144,9 +144,8 @@ module Xlat
 
       # Flow label = 0
 
-      # Total Length = copy from IPv4; may be updated in later step
-      ipv4_length = ipv4_bytes.get_value(:U16, ipv4_bytes_offset + 2)
-      ipv6_length = ipv4_length - 20
+      # IPv6 Length = IPv4 total length - IPv4 header length; may be updated in later step
+      ipv6_length = ipv4_packet.l4_length
       # not considering as a checksum delta because upper layer packet length doesn't take this into account; cs_delta += ipv4_length - ipv6_length
       new_header_buffer.set_value(:U16, 4, ipv6_length)
 

--- a/spec/protocols_spec.rb
+++ b/spec/protocols_spec.rb
@@ -59,6 +59,21 @@ RSpec.describe Xlat::Protocols::Ip do
       end
     end
 
+    it 'parses IPv4 with IP options' do
+      ip = subject.parse(bytes: TestPackets::TEST_PACKET_IPV4_OPTS_UDP)
+      aggregate_failures do
+        expect(ip).to be_kind_of Xlat::Protocols::Ip
+        expect(ip.version).to eq Xlat::Protocols::Ip::Ipv4
+        expect(ip.proto).to eq 17
+        expect(ip.l4_start).to eq 24
+        expect(ip.l4_length).to eq 9
+        expect(ip.l4).to be_kind_of Xlat::Protocols::Udp
+        expect(ip.l4_bytes).to be ip.bytes
+        expect(ip.l4_bytes_offset).to eq 24
+        expect(ip.l4_bytes_length).to eq 9
+      end
+    end
+
     it 'parses IPv4 ICMP Echo' do
       ip = subject.parse(bytes: TestPackets::TEST_PACKET_IPV4_ICMP_ECHO)
       aggregate_failures do

--- a/spec/rfc7915_spec.rb
+++ b/spec/rfc7915_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe Xlat::Rfc7915 do
       bytes = TestPackets.const_get(test_packet_const_name)
       describe test_packet_const_name do
         let(:output) do
-          hdrlen = (version == 4 ? 20 : 40)
+          hdrlen = (version == 4 ? (bytes.get_value(:U8, 0) & 0x0f)*4 : 40)
           [
             bytes.slice(0, hdrlen),
             bytes.slice(hdrlen),
@@ -324,6 +324,14 @@ RSpec.describe Xlat::Rfc7915 do
 
       it "translates into ipv6" do
         expect_packet_equal(6, TestPackets::TEST_PACKET_IPV6_ETHERIP, output)
+      end
+    end
+
+    context "with IPv4 Options" do
+      let!(:output) { translator.translate_to_ipv6(Xlat::Protocols::Ip.parse(TestPackets::TEST_PACKET_IPV4_OPTS_UDP.dup), 1500) }
+
+      it "translates into ipv6" do
+        expect_packet_equal(6, TestPackets::TEST_PACKET_IPV6_UDP, output)
       end
     end
 

--- a/spec/test_packets.rb
+++ b/spec/test_packets.rb
@@ -27,6 +27,29 @@ module TestPackets
     %w(af),
   ]
 
+  TEST_PACKET_IPV4_OPTS_UDP = buffer [
+    # ipv4
+    %w(46 00), # header len (24)
+    %w(00 21), # total length (24+8+1=33)
+    %w(c3 98), # identification
+    %w(00 00), # flags
+    %w(40), # ttl
+    %w(11), # protocol
+    %w(e7 6c), # checksum
+    %w(c0 00 02 07), # src
+    %w(c0 00 02 08), # dst
+    %w(1e 04 2c b3), # opt: experimental
+
+    # udp
+    %w(c1 5b), # src port
+    %w(00 35), # dst port
+    %w(00 09), # length
+    %w(0b 3b), # checksum
+
+    # payload
+    %w(af),
+  ]
+
   TEST_PACKET_IPV6_UDP = buffer [
     # ipv6
     %w(60 00 00 00), # version, qos, flow label


### PR DESCRIPTION
RFC7915 Section 4.1:
> If any IPv4 options are present in the IPv4 packet, they MUST be
> ignored and the packet translated normally

TODO:
> However, if an unexpired source route option is present,
> then the packet MUST instead be discarded