### PR TITLE
adapters: Eliminate IO::Buffer allocation in `LinuxTun#read`

### DIFF
--- a/lib/xlat/adapters/linux_tun.rb
+++ b/lib/xlat/adapters/linux_tun.rb
@@ -33,8 +33,7 @@ module Xlat
       end
 
       def read(buf)
-        size = IOBufferExt.readv(@io, [buf])
-        buf.slice(0, size)
+        IOBufferExt.readv(@io, [buf])
       end
 
       def write(*bufs)


### PR DESCRIPTION
This patch changes the interface of `Xlat::Adapters::LinuxTun#read` to return the number of bytes read from the TUN device, instead of an `IO::Buffer` slice.

This reduces one `IO::Buffer` allocation per packet.