### PR TITLE
IPv6 extension headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ TODO: Write usage instructions here
 
 ## Caveats
 
-- Packets with IPv6 extensions are silently discarded; Unsupported.
 - Expecting no difference in IPv4 and IPv6 MTU
 - Fragmented packets are silently discarded
 

--- a/spec/protocols_spec.rb
+++ b/spec/protocols_spec.rb
@@ -74,6 +74,21 @@ RSpec.describe Xlat::Protocols::Ip do
       end
     end
 
+    it 'parses IPv6 with extension header' do
+      ip = subject.parse(bytes: TestPackets::TEST_PACKET_IPV6_HOPOPT_DSTOPT_UDP)
+      aggregate_failures do
+        expect(ip).to be_kind_of Xlat::Protocols::Ip
+        expect(ip.version).to eq Xlat::Protocols::Ip::Ipv6
+        expect(ip.proto).to eq 17
+        expect(ip.l4_start).to eq 72
+        expect(ip.l4_length).to eq 9
+        expect(ip.l4).to be_kind_of Xlat::Protocols::Udp
+        expect(ip.l4_bytes).to be ip.bytes
+        expect(ip.l4_bytes_offset).to eq 72
+        expect(ip.l4_bytes_length).to eq 9
+      end
+    end
+
     it 'parses IPv4 ICMP Echo' do
       ip = subject.parse(bytes: TestPackets::TEST_PACKET_IPV4_ICMP_ECHO)
       aggregate_failures do

--- a/spec/test_packets.rb
+++ b/spec/test_packets.rb
@@ -69,6 +69,35 @@ module TestPackets
     %w(af),
   ]
 
+  TEST_PACKET_IPV6_HOPOPT_DSTOPT_UDP = buffer [
+    # ipv6
+    %w(60 00 00 00), # version, qos, flow label
+    %w(00 29), # payload length (8+16+16+1=41)
+    %w(00), # next header (hopopt)
+    %w(40), # hop limit
+    %w(20 01 0d b8 00 60 00 00 00 00 00 00 c0 00 02 07), # src
+    %w(20 01 0d b8 00 64 00 00 00 00 00 00 c0 00 02 08), # dst
+
+    # hopopt
+    %w(3c), # next header (ipv6-opts)
+    %w(01), # header extension length (=16)
+    %w(1e 0c 01 02 03 04 05 06 07 08 09 0a 0b 0c),
+
+    # ipv6-opts
+    %w(11), # next header (udp)
+    %w(01), # header extension length (=16)
+    %w(1e 0c 01 02 03 04 05 06 07 08 09 0a 0b 0c),
+
+    # udp
+    %w(c1 5b), # src port
+    %w(00 35), # dst port
+    %w(00 09), # length
+    %w(af 04), # checksum
+
+    # payload
+    %w(af),
+  ]
+
   TEST_PACKET_IPV4_TCP = buffer [
     # ipv4
     %w(45 00),


### PR DESCRIPTION
RFC 7915 requires SIIT translators to ignore Hop-by-Hop Options and Destination Options IPv6 extension headers. This patch implements basic handling of extension headers (and just ignore them).