### PR TITLE
spec: RSpec matchers for packet inspection

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,3 +18,132 @@ config.run_all_when_everything_filtered = true
 end
 
 RSpec::Matchers.define_negated_matcher :not_change, :change
+
+# expected_packet: IO::Buffer
+# actual_packet: Array<IO::Buffer>
+RSpec::Matchers.define :match_packet do |expected_packet_, adjust_ttl: -1|
+  match do |actual_packet|
+    @expected_packet = expected_packet_.dup
+    case @expected_packet.get_value(:U8, 0) >> 4
+    when 4
+      @expected_packet.set_value(:U8, 8, @expected_packet.get_value(:U8, 8) + adjust_ttl)
+      cs = @expected_packet.get_value(:U16, 10)
+      cs = Xlat::Protocols::Ip.checksum_adjust(cs, 256 * adjust_ttl)
+      @expected_packet.set_value(:U16, 10, cs)
+    when 6
+      @expected_packet.set_value(:U8, 7, @expected_packet.get_value(:U8, 7) + adjust_ttl)
+    else
+      raise ArgumentError, 'unsupported IP version'
+    end
+
+    @expected_packet.get_string == actual_packet.map(&:get_string).join
+  end
+
+  failure_message do |actual_packet|
+    wrap = 16
+
+    msg = +<<~EOF
+      Expected the packet to match:
+            #{' EXPECTED '.center(3*wrap+wrap/8-2, ?-)} | #{' ACTUAL '.center(3*wrap+wrap/8-2, ?-)}
+    EOF
+
+    expected_bytes = @expected_packet.get_string
+    actual_bytes = actual_packet.map(&:get_string).join
+    length = [expected_bytes.size, actual_bytes.size].max
+
+    hex = lambda {|byte| byte ? byte.unpack1('H2') : '  ' }
+
+    (0...length).step(wrap) do |offset|
+      l_expected = +''
+      l_actual = +''
+
+      wrap.times do |i|
+        if i % 8 == 0
+          l_expected << ' '
+          l_actual << ' '
+        end
+
+        if RSpec.configuration.color and expected_bytes[offset + i] != actual_bytes[offset + i]
+          mark, unmark = "\e[1;4m", "\e[22;24m"  # Bold & underline
+        else
+          mark = unmark = ''
+        end
+
+        l_expected << mark << hex[expected_bytes[offset + i]] << unmark << ' '
+        l_actual << mark << hex[actual_bytes[offset + i]] << unmark << ' '
+      end
+
+      msg << sprintf('%04x', offset) << ':' << l_expected << '|' << l_actual << ?\n
+    end
+
+    msg
+  end
+end
+
+# acutual_packet: Array<IO::Buffer>
+RSpec::Matchers.define :have_correct_checksum do |version:, l4: true|
+  match do |actual_packet|
+    packet = IO::Buffer.for(actual_packet.map(&:get_string).join)
+    actual_version = packet.get_value(:U8, 0) >> 4
+
+    if version != actual_version
+      raise 'unexpected IP version'
+    end
+
+    case version
+    when 4
+      l4proto = packet.get_value(:U8, 9)
+      l4offset = (packet.get_value(:U8, 0) & 0xf) * 4
+      l4length = packet.get_value(:U16, 2) - l4offset
+      unless Xlat::Protocols::Ip.checksum(packet.slice(0, l4offset)) == 0
+        raise 'incorrect IPv4 checksum'
+      end
+    when 6
+      l4proto = packet.get_value(:U8, 6)
+      l4offset = 40
+      loop do
+        case l4proto
+        when 0, 43, 60, 135, 139, 140, 253, 254
+          l4proto = packet.get_value(:U8, l4offset)
+          l4offset += packet.get_value(:U8, l4offset + 1) * 8 + 8
+        when 44  # Fragment
+          l4proto = packet.get_value(:U8, l4offset)
+          l4offset += 8
+        when 51  # AH
+          l4proto = packet.get_value(:U8, l4offset)
+          l4offset += packet.get_value(:U8, l4offset + 1) * 4 + 8
+        else
+          break
+        end
+      end
+      l4length = packet.get_value(:U16, 4) - (l4offset - 40)
+    else
+      raise 'unsupported IP version'
+    end
+
+    if l4offset + l4length != packet.size
+      raise 'wrong packet length in L3 header'
+    end
+
+    pseudo_header = [
+      version == 4 ? packet.slice(12, 4) : packet.slice(8, 16),
+      version == 4 ? packet.slice(16, 4) : packet.slice(24, 16),
+      IO::Buffer.for([0, l4proto, l4length].pack('CCn')),
+    ]
+    if l4proto == 1  # ICMP
+      pseudo_header = []
+    end
+
+    case l4proto
+    when 1, 6, 17, 58  # ICMP, TCP, UDP, ICMPv6
+      l4data = packet.slice(l4offset, l4length)
+      if Xlat::Protocols::Ip.checksum_list([*pseudo_header, l4data]) != 0
+        raise 'incorrect L4 checksum'
+      end
+    else
+      raise 'L4 checksum requested but not supported' if l4
+    end
+
+    true
+  end
+end


### PR DESCRIPTION
- have_correct_checksum: Checks for IPv4 checksum and L4 checksum (UDP/TCP/ICMP/ICMPv6).
- match_packet: Compares content of IO::Buffer, with graphical diff.
  <img width="1054" alt="image" src="https://github.com/user-attachments/assets/de068284-d9e4-4834-bbe1-f6dc989033c4" />
