### PR TITLE
protocols/ip: parse fragments

### DIFF
--- a/spec/protocols_spec.rb
+++ b/spec/protocols_spec.rb
@@ -18,6 +18,11 @@ RSpec.describe Xlat::Protocols::Ip do
         expect(ip.l4_bytes).to be ip.bytes
         expect(ip.l4_bytes_offset).to eq 20
         expect(ip.l4_bytes_length).to eq 33
+
+        expect(ip.identification).to eq 0xC398
+        expect(ip.fragment_offset).to be nil
+        expect(ip.more_fragments).to be nil
+        expect(ip.dont_fragment).to be false
       end
     end
 
@@ -31,6 +36,11 @@ RSpec.describe Xlat::Protocols::Ip do
         expect(ip.l4_bytes).to be ip.bytes
         expect(ip.l4_bytes_offset).to eq 40
         expect(ip.l4_bytes_length).to eq 33
+
+        expect(ip.identification).to eq nil
+        expect(ip.fragment_offset).to be nil
+        expect(ip.more_fragments).to be nil
+        expect(ip.dont_fragment).to be nil
       end
     end
 
@@ -249,6 +259,142 @@ RSpec.describe Xlat::Protocols::Ip do
         expect(inner.l4).to be_kind_of Xlat::Protocols::Udp
         expect(inner.l4_bytes_offset).to eq 88
         expect(inner.l4_bytes_length).to eq 9
+      end
+    end
+
+    context 'IPv4 fragmentation' do
+      it 'parses IPv4 fragmented UDP (first fragment)' do
+        ip = subject.parse(bytes: TestPackets::TEST_PACKET_IPV4_FRAG_UDP_0_1472)
+        aggregate_failures do
+          expect(ip).to be_kind_of Xlat::Protocols::Ip
+          expect(ip.version).to eq Xlat::Protocols::Ip::Ipv4
+          expect(ip.identification).to eq 0xc398
+          expect(ip.fragment_offset).to eq 0
+          expect(ip.more_fragments).to be true
+          expect(ip.dont_fragment).to be false
+          expect(ip.l4).to be_kind_of Xlat::Protocols::Udp
+          expect(ip.l4_bytes).to be ip.bytes
+          expect(ip.l4_bytes_offset).to eq 20
+          expect(ip.l4_bytes_length).to eq 1480
+        end
+      end
+
+      it 'parses IPv4 fragmented UDP (continued fragment)' do
+        ip = subject.parse(bytes: TestPackets::TEST_PACKET_IPV4_FRAG_UDP_1472_1600)
+        aggregate_failures do
+          expect(ip).to be_kind_of Xlat::Protocols::Ip
+          expect(ip.version).to eq Xlat::Protocols::Ip::Ipv4
+          expect(ip.identification).to eq 0xc398
+          expect(ip.fragment_offset).to eq 185
+          expect(ip.more_fragments).to be false
+          expect(ip.dont_fragment).to be false
+          expect(ip.l4).to be_nil
+          expect(ip.l4_bytes).to be ip.bytes
+          expect(ip.l4_bytes_offset).to eq 20
+          expect(ip.l4_bytes_length).to eq 128
+        end
+      end
+
+      it 'parses IPv4 fragmented UDP within ICMPv4 error' do
+        ip = subject.parse(bytes: TestPackets::TEST_PACKET_IPV4_ICMP_FRAG_PAYLOAD)
+        aggregate_failures do
+          expect(ip).to be_kind_of Xlat::Protocols::Ip
+          expect(ip.version).to eq Xlat::Protocols::Ip::Ipv4
+          expect(ip.l4).to be_kind_of Xlat::Protocols::Icmp::Error
+          expect(ip.l4_bytes).to be ip.bytes
+          expect(ip.l4_bytes_offset).to eq 20
+          expect(ip.identification).to eq 0xc398
+          expect(ip.fragment_offset).to be_nil
+          expect(ip.more_fragments).to be_nil
+          expect(ip.dont_fragment).to be false
+          expect(ip.l4.type).to eq 3
+          expect(ip.l4.code).to eq 10
+          expect(ip.l4.payload_bytes).to be ip.bytes
+          expect(ip.l4.payload_bytes_offset).to eq 28
+        end
+
+        inner = Xlat::Protocols::Ip.new(icmp_payload: true)
+          .parse(bytes: ip.l4.payload_bytes, bytes_offset: ip.l4.payload_bytes_offset, bytes_length: ip.l4.payload_bytes_length)
+        aggregate_failures do
+          expect(inner).to be_kind_of Xlat::Protocols::Ip
+          expect(inner.version).to eq Xlat::Protocols::Ip::Ipv4
+          expect(inner.l4).to be_kind_of Xlat::Protocols::Udp
+          expect(inner.l4_bytes).to be ip.bytes
+          expect(inner.l4_bytes_offset).to eq 48
+          expect(inner.l4_bytes_length).to eq 16
+          expect(inner.identification).to eq 0xc398
+          expect(inner.fragment_offset).to eq 0
+          expect(inner.more_fragments).to be true
+          expect(inner.dont_fragment).to be false
+        end
+      end
+    end
+
+    context 'IPv6 fragmentation' do
+      it 'parses IPv6 fragmented UDP (first fragment)' do
+        ip = subject.parse(bytes: TestPackets::TEST_PACKET_IPV6_FRAG_UDP_0_1440)
+        aggregate_failures do
+          expect(ip).to be_kind_of Xlat::Protocols::Ip
+          expect(ip.version).to eq Xlat::Protocols::Ip::Ipv6
+          expect(ip.identification).to eq 0xc398
+          expect(ip.fragment_offset).to eq 0
+          expect(ip.more_fragments).to be true
+          expect(ip.dont_fragment).to be_nil
+          expect(ip.l4).to be_kind_of Xlat::Protocols::Udp
+          expect(ip.l4_bytes).to be ip.bytes
+          expect(ip.l4_bytes_offset).to eq 48
+          expect(ip.l4_bytes_length).to eq 1448
+        end
+      end
+
+      it 'parses IPv6 fragmented UDP (continued fragment)' do
+        ip = subject.parse(bytes: TestPackets::TEST_PACKET_IPV6_FRAG_UDP_1440_1600)
+        aggregate_failures do
+          expect(ip).to be_kind_of Xlat::Protocols::Ip
+          expect(ip.version).to eq Xlat::Protocols::Ip::Ipv6
+          expect(ip.identification).to eq 0xc398
+          expect(ip.fragment_offset).to eq 181
+          expect(ip.more_fragments).to be false
+          expect(ip.dont_fragment).to be_nil
+          expect(ip.l4).to be_nil
+          expect(ip.l4_bytes).to be ip.bytes
+          expect(ip.l4_bytes_offset).to eq 48
+          expect(ip.l4_bytes_length).to eq 160
+        end
+      end
+
+      it 'parses IPv6 fragmented UDP within ICMPv6 error' do
+        ip = subject.parse(bytes: TestPackets::TEST_PACKET_IPV6_ICMP_FRAG_PAYLOAD)
+        aggregate_failures do
+          expect(ip).to be_kind_of Xlat::Protocols::Ip
+          expect(ip.version).to eq Xlat::Protocols::Ip::Ipv6
+          expect(ip.l4).to be_kind_of Xlat::Protocols::Icmp::Error
+          expect(ip.l4_bytes).to be ip.bytes
+          expect(ip.l4_bytes_offset).to eq 40
+          expect(ip.identification).to be_nil
+          expect(ip.fragment_offset).to be_nil
+          expect(ip.more_fragments).to be_nil
+          expect(ip.dont_fragment).to be nil
+          expect(ip.l4.type).to eq 1
+          expect(ip.l4.code).to eq 1
+          expect(ip.l4.payload_bytes).to be ip.bytes
+          expect(ip.l4.payload_bytes_offset).to eq 48
+        end
+
+        inner = Xlat::Protocols::Ip.new(icmp_payload: true)
+          .parse(bytes: ip.l4.payload_bytes, bytes_offset: ip.l4.payload_bytes_offset, bytes_length: ip.l4.payload_bytes_length)
+        aggregate_failures do
+          expect(inner).to be_kind_of Xlat::Protocols::Ip
+          expect(inner.version).to eq Xlat::Protocols::Ip::Ipv6
+          expect(inner.l4).to be_kind_of Xlat::Protocols::Udp
+          expect(inner.l4_bytes).to be ip.bytes
+          expect(inner.l4_bytes_offset).to eq 96  # 40(ipv6)+8(icmpv6)+40(ipv6)+8(ipv6-frag)
+          expect(inner.l4_bytes_length).to eq 16
+          expect(inner.identification).to eq 0xc398
+          expect(inner.fragment_offset).to eq 0
+          expect(inner.more_fragments).to be true
+          expect(inner.dont_fragment).to be_nil
+        end
       end
     end
   end

--- a/spec/rfc7915_spec.rb
+++ b/spec/rfc7915_spec.rb
@@ -50,9 +50,9 @@ RSpec.describe Xlat::Rfc7915 do
 
   describe "meta" do
     TestPackets.constants.grep(/TEST_PACKET_/).uniq.each do |test_packet_const_name|
-      version = test_packet_const_name.to_s.include?('IPV4') ? 4 : 6
-      l4cksum = test_packet_const_name.to_s.match?(/_TRUE_|DNS|ICMP|TCP|UDP/i)
       bytes = TestPackets.const_get(test_packet_const_name)
+      version = test_packet_const_name.to_s.include?('IPV4') ? 4 : 6
+      l4cksum = test_packet_const_name.to_s.match?(/_TRUE_|DNS|ICMP|TCP|UDP/i) && !bytes.respond_to?(:__no_l4_checksum)
       describe test_packet_const_name do
         it do
           expect([bytes]).to have_correct_checksum(version:, l4: l4cksum)

--- a/spec/test_packets.rb
+++ b/spec/test_packets.rb
@@ -155,6 +155,129 @@ module TestPackets
     %w(af),
   ]
 
+  TEST_PACKET_IPV4_FRAG_ORIGINAL = buffer [
+    # ipv4
+    %w(45 00),
+    %w(06 5c), # total length (20+8+1600=1628)
+    %w(c3 98), # identification
+    %w(00 00), # flags
+    %w(40), # ttl
+    %w(11), # protocol
+    %w(2c e9), # checksum
+    %w(c0 00 02 07), # src
+    %w(c0 00 02 08), # dst
+
+    # udp
+    %w(c1 5b), # src port
+    %w(00 35), # dst port
+    %w(06 48), # length (1608)
+    %w(67 77), # checksum
+
+    # payload
+    %w(de ad be ef) * (1600 / 4),
+  ]
+  TEST_PACKET_IPV4_FRAG_UDP_0_1472 = buffer [
+    # ipv4
+    %w(45 00),
+    %w(05 dc), # total length (20+8+1472=1500)
+    %w(c3 98), # identification
+    %w(20 00), # flags (MF)
+    %w(40), # ttl
+    %w(11), # protocol
+    %w(0d 69), # checksum
+    %w(c0 00 02 07), # src
+    %w(c0 00 02 08), # dst
+
+    # udp
+    %w(c1 5b), # src port
+    %w(00 35), # dst port
+    %w(06 48), # length (1608)
+    %w(67 77), # checksum
+
+    # payload
+    %w(de ad be ef) * (1472 / 4),
+  ]
+  def TEST_PACKET_IPV4_FRAG_UDP_0_1472.__no_l4_checksum = true
+  TEST_PACKET_IPV4_FRAG_UDP_1472_1600 = buffer [
+    # ipv4
+    %w(45 00),
+    %w(00 94), # total length (20+128=148)
+    %w(c3 98), # identification
+    %w(00 b9), # flags / offset (1480/8=185)
+    %w(40), # ttl
+    %w(11), # protocol
+    %w(31 f8), # checksum
+    %w(c0 00 02 07), # src
+    %w(c0 00 02 08), # dst
+
+    # udp payload (cont.)
+    %w(de ad be ef) * (128 / 4),
+  ]
+  def TEST_PACKET_IPV4_FRAG_UDP_1472_1600.__no_l4_checksum = true
+
+  TEST_PACKET_IPV6_FRAG_ORIGINAL = buffer [
+    # ipv6
+    %w(60 00 00 00), # version, qos, flow label
+    %w(06 48), # payload length (8+1600=1608)
+    %w(11), # next header
+    %w(40), # hop limit
+    %w(20 01 0d b8 00 60 00 00 00 00 00 00 c0 00 02 07), # src
+    %w(20 01 0d b8 00 64 00 00 00 00 00 00 c0 00 02 08), # dst
+
+    # udp
+    %w(c1 5b), # src port
+    %w(00 35), # dst port
+    %w(06 48), # length (1608)
+    %w(0b 41), # checksum
+
+    # payload
+    %w(de ad be ef) * (1600 / 4),
+  ]
+  TEST_PACKET_IPV6_FRAG_UDP_0_1440 = buffer [
+    # ipv6
+    %w(60 00 00 00), # version, qos, flow label
+    %w(05 b0), # payload length (8+8+1440=1456)
+    %w(2c), # next header
+    %w(40), # hop limit
+    %w(20 01 0d b8 00 60 00 00 00 00 00 00 c0 00 02 07), # src
+    %w(20 01 0d b8 00 64 00 00 00 00 00 00 c0 00 02 08), # dst
+
+    # ipv6-frag
+    %w(11), # next header (udp)
+    %w(00), # reserved
+    %w(00 01), # fragment offset (0) / flags (M)
+    %w(00 00 c3 98), # identification
+
+    # udp
+    %w(c1 5b), # src port
+    %w(00 35), # dst port
+    %w(06 48), # length (1608)
+    %w(0b 41), # checksum
+
+    # payload
+    %w(de ad be ef) * (1440 / 4),
+  ]
+  def TEST_PACKET_IPV6_FRAG_UDP_0_1440.__no_l4_checksum = true
+  TEST_PACKET_IPV6_FRAG_UDP_1440_1600 = buffer [
+    # ipv6
+    %w(60 00 00 00), # version, qos, flow label
+    %w(00 a8), # payload length (8+160=168)
+    %w(2c), # next header
+    %w(40), # hop limit
+    %w(20 01 0d b8 00 60 00 00 00 00 00 00 c0 00 02 07), # src
+    %w(20 01 0d b8 00 64 00 00 00 00 00 00 c0 00 02 08), # dst
+
+    # ipv6-frag
+    %w(11), # next header (udp)
+    %w(00), # reserved
+    %w(05 a8), # fragment offset (1448/8=181) / flags
+    %w(00 00 c3 98), # identification
+
+    # udp payload (cont.)
+    %w(de ad be ef) * (160 / 4),
+  ]
+  def TEST_PACKET_IPV6_FRAG_UDP_1440_1600.__no_l4_checksum = true
+
   TEST_PACKET_IPV4_ICMP_ECHO = buffer [
     # ipv4
     %w(45 00),


### PR DESCRIPTION
Protocols::Ip can now parse fragmented IPv4/v6 datagrams.

Rfc7915 drops fragmented packets (for now!).