### PR TITLE
Translate fragments

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ TODO: Write usage instructions here
 ## Caveats
 
 - Expecting no difference in IPv4 and IPv6 MTU
-- Fragmented packets are silently discarded
+- If an IPv4 packet is translated into an IPv6 packet larger than MTU, the packet is silently discarded.
 
 ## Tips
 

--- a/lib/xlat/rfc7915.rb
+++ b/lib/xlat/rfc7915.rb
@@ -27,6 +27,7 @@ module Xlat
 
       @ipv4_new_header_buffer = IO::Buffer.new(20)
       @ipv6_new_header_buffer = IO::Buffer.new(40)
+      @ipv6_fragment_header_buffer = IO::Buffer.new(8)
       @output = []
       @new_header_buffer_in_use = false
       return_buffer_ownership
@@ -176,11 +177,44 @@ module Xlat
 
       # IPv6 Length = IPv4 total length - IPv4 header length; may be updated in later step
       ipv6_length = ipv4_packet.l4_length
+
+      ipv4_proto = ipv4_packet.proto
+
+      if fragment_offset = ipv4_packet.fragment_offset
+        if ipv4_proto == 1 # icmpv4
+          # TODO: what if an ICMPv4 packet is fragmented?
+          return return_buffer_ownership()
+        end
+
+        fragment_header = @ipv6_fragment_header_buffer
+
+        # next header = copy from IPv4
+        fragment_header.set_value(:U8, 0, ipv4_proto)
+
+        # reserved = zero; just leave it as it is never set
+        # fragment_header.set_value(:U8, 1, 0)
+
+        # Fragment offset and flags = copy from IPv4
+        offset_flags = (fragment_offset << 3) | (ipv4_packet.more_fragments ? 1 : 0)
+        fragment_header.set_value(:U16, 2, offset_flags)
+
+        # identification = copy from IPv4; upper 16 bits are zero (never set)
+        fragment_header.set_value(:U16, 6, ipv4_packet.identification)
+
+        # IPv6 payload length contains the fragment header
+        ipv6_length += 8
+        # Next Header = ipv6-frag
+        ipv6_nexthdr = 44
+
+        max_length -= 8  # fragment header
+      else  # non-fragments
+        # Next Header = copy from IPv4; may be updated in later step for ICMPv6=>4 conversion
+        ipv6_nexthdr = ipv4_proto
+      end
+
       # not considering as a checksum delta because upper layer packet length doesn't take this into account; cs_delta += ipv4_length - ipv6_length
       new_header_buffer.set_value(:U16, 4, ipv6_length)
-
-      # Next Header = copy from IPv4; may be updated in later step for ICMPv6=>4 conversion
-      new_header_buffer.set_value(:U8, 6, ipv4_packet.proto)
+      new_header_buffer.set_value(:U8, 6, ipv6_nexthdr)
 
       # Hop limit = copy from IPv4
       new_header_buffer.set_value(:U8, 7, ipv4_bytes.get_value(:U8, ipv4_bytes_offset + 8))
@@ -190,10 +224,7 @@ module Xlat
       cs_delta_b = @source_address_translator.translate_address_to_ipv6(ipv4_bytes.slice(ipv4_bytes_offset + 16,4), new_header_buffer, 24) or return return_buffer_ownership()
       cs_delta += cs_delta_a + cs_delta_b
 
-      # TODO: fragmentation
-      return return_buffer_ownership() if ipv4_packet.fragment_offset
-
-      if ipv4_packet.proto == 1 # icmpv4
+      if ipv4_proto == 1
         icmp_result, icmp_output = translate_icmpv4_to_icmpv6(ipv4_packet, new_header_buffer, max_length - 40)
         return return_buffer_ownership() unless icmp_result
         cs_delta += icmp_result
@@ -201,8 +232,9 @@ module Xlat
 
       unless icmp_output
         l4_length = ipv4_packet.l4_bytes_length
-        unless 40 + l4_length <= max_length
+        if 40 + l4_length > max_length
           if icmp_payload
+            # If icmp_output.nil?, ICMP payload is not structured (RFC4884), thus simply truncatable
             l4_length = max_length - 40
           else
             # FIXME: generate "fragmentation needed" if DF=1
@@ -218,6 +250,7 @@ module Xlat
       # TODO: Section 4.4.  Generation of ICMPv4 Error Message
 
       @output << new_header_buffer
+      @output << fragment_header if fragment_header
       if icmp_output
         @output.concat(icmp_output)
       else

--- a/spec/rfc7915_spec.rb
+++ b/spec/rfc7915_spec.rb
@@ -86,6 +86,24 @@ RSpec.describe Xlat::Rfc7915 do
       end
     end
 
+    context "with fragmentation" do
+      context "head fragment" do
+        let!(:output) { translator.translate_to_ipv4(parse_packet(TestPackets::TEST_PACKET_IPV6_FRAG_UDP_0_1440.dup), 1500) }
+
+        it "translates into ipv4" do
+          expect(output).to have_correct_checksum(version: 4, l4: false).and match_packet(TestPackets::TEST_PACKET_IPV4_FRAG_UDP_0_1440)
+        end
+      end
+
+      context "tail fragment" do
+        let!(:output) { translator.translate_to_ipv4(parse_packet(TestPackets::TEST_PACKET_IPV6_FRAG_UDP_1440_1600.dup), 1500) }
+
+        it "translates into ipv4" do
+          expect(output).to have_correct_checksum(version: 4, l4: false).and match_packet(TestPackets::TEST_PACKET_IPV4_FRAG_UDP_1440_1600)
+        end
+      end
+    end
+
     context "with icmp echo" do
       let!(:output) { translator.translate_to_ipv4(parse_packet(TestPackets::TEST_PACKET_IPV6_ICMP_ECHO.dup), 1500) }
 
@@ -130,7 +148,7 @@ RSpec.describe Xlat::Rfc7915 do
       let!(:output) { translator.translate_to_ipv4(parse_packet(TestPackets::TEST_PACKET_IPV6_ICMP_FRAG_PAYLOAD.dup), 1500) }
 
       it "translates into ipv4" do
-        expect(output).to be_nil  # Though we don't support fragments yet, it should not raise
+        expect(output).to have_correct_checksum(version: 4).and match_packet(TestPackets::TEST_PACKET_IPV4_ICMP_FRAG_PAYLOAD)
       end
     end
 

--- a/spec/test_packets.rb
+++ b/spec/test_packets.rb
@@ -215,6 +215,45 @@ module TestPackets
   ]
   def TEST_PACKET_IPV4_FRAG_UDP_1472_1600.__no_l4_checksum = true
 
+  TEST_PACKET_IPV4_FRAG_UDP_0_1440 = buffer [
+    # ipv4
+    %w(45 00),
+    %w(05 bc), # total length (20+8+1440=1468)
+    %w(c3 98), # identification
+    %w(20 00), # flags (MF)
+    %w(40), # ttl
+    %w(11), # protocol
+    %w(0d 89), # checksum
+    %w(c0 00 02 07), # src
+    %w(c0 00 02 08), # dst
+
+    # udp
+    %w(c1 5b), # src port
+    %w(00 35), # dst port
+    %w(06 48), # length (1608)
+    %w(67 77), # checksum
+
+    # payload
+    %w(de ad be ef) * (1440 / 4),
+  ]
+  def TEST_PACKET_IPV4_FRAG_UDP_0_1440.__no_l4_checksum = true
+  TEST_PACKET_IPV4_FRAG_UDP_1440_1600 = buffer [
+    # ipv4
+    %w(45 00),
+    %w(00 b4), # total length (20+160=180)
+    %w(c3 98), # identification
+    %w(00 b5), # flags / offset (1448/8=181)
+    %w(40), # ttl
+    %w(11), # protocol
+    %w(31 dc), # checksum
+    %w(c0 00 02 07), # src
+    %w(c0 00 02 08), # dst
+
+    # udp payload (cont.)
+    %w(de ad be ef) * (160 / 4),
+  ]
+  def TEST_PACKET_IPV4_FRAG_UDP_1440_1600.__no_l4_checksum = true
+
   TEST_PACKET_IPV6_FRAG_ORIGINAL = buffer [
     # ipv6
     %w(60 00 00 00), # version, qos, flow label


### PR DESCRIPTION
This patch set implements the translation of fragmented packets: IPv4/IPv6 packets that are already fragmented are translated into the other version. In IPv4-to-IPv6 translation, the size of the IPv6 packet can exceed MTU, in which case the packet will be discarded.

Fragmented ICMPv4/ICMPv6 packets are discarded. RFC 7915 was not clear to me on how to handle such ICMP packets.
\S [1.2](https://datatracker.ietf.org/doc/html/rfc7915#section-1.2). (non-normatively) states:
> Fragmented ICMP/ICMPv6 packets will not be translated by IP/ICMP translators.

while \S [4.1](https://datatracker.ietf.org/doc/html/rfc7915#section-4.1). and \S [5.1.1](https://datatracker.ietf.org/doc/html/rfc7915#section-5.1.1). define how to construct IP headers for fragmented ICMP packets.

It seems impossible to translate fragmented RFC4884-style ICMP errors statelessly since the ICMP header defines the structure of the ICMP payload (ICMPv4 and ICMPv6 have different structures).