### PR TITLE
Allocationless address translator interface

### DIFF
--- a/lib/xlat/address_translation.rb
+++ b/lib/xlat/address_translation.rb
@@ -2,24 +2,27 @@
 
 module Xlat
   module AddressTranslation
-    # Translate IPv6 address bytestring into IPv4 address and write to given buffer
-    # Must return true when translation took place
+    # Translate IPv6 address in the given IO::Buffer into IPv4 address and write to another IO::Buffer.
+    # Must return true when translation took place.
     #
-    # @param ipv6_address [IO::Buffer] IPv6 address buffer
-    # @param buffer [IO::Buffer] Destination packet buffer
-    # @param offset [Integer] Offset in buffer to write IPv6 address
+    # @param source [IO::Buffer] Buffer from which IPv6 address is read
+    # @param source_offset [Integer] Offset in the source IO::Buffer
+    # @param destination [IO::Buffer] Buffer into which IPv4 address is written
+    # @param destination_offset [Integer] Offset in the destination IO::Buffer
     # @return [Integer, nil] checksum delta value or nil when no translation took place
-    def translate_address_to_ipv4(ipv6_address,buffer,offset = 0)
+    def translate_address_to_ipv4(source, source_offset, destination, destination_offset)
       raise NotImplementedError
     end
 
-    # Translate IPv4 address bytestring into IPv6 address and write to given buffer
+    # Translate IPv4 address in the given IO::Buffer into IPv6 address and write to another IO::Buffer.
+    # Must return true when translation took place.
     #
-    # @param ipv4_address [IO::Buffer] IPv4 address buffer
-    # @param buffer [IO::Buffer] Destination packet buffer
-    # @param offset [Integer] Offset in buffer to write IPv4 address
+    # @param source [IO::Buffer] Buffer from which IPv4 address is read
+    # @param source_offset [Integer] Offset in the source IO::Buffer
+    # @param destination [IO::Buffer] Buffer into which IPv6 address is written
+    # @param destination_offset [Integer] Offset in the destination IO::Buffer
     # @return [Integer, nil] checksum delta value or nil when no translation took place
-    def translate_address_to_ipv6(ipv4_address,buffer,offset = 0)
+    def translate_address_to_ipv6(source, source_offset, destination, destination_offset)
       raise NotImplementedError
     end
 

--- a/lib/xlat/address_translators/rfc6052.rb
+++ b/lib/xlat/address_translators/rfc6052.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require 'xlat/address_translation'
+require 'xlat/io_buffer_ext'
 require 'xlat/common'
 require 'ipaddr'
 
@@ -28,16 +29,18 @@ module Xlat
         @negative_cs_delta = -@cs_delta
       end
 
-      def translate_address_to_ipv4(ipv6_address,buffer,offset = 0)
-        return unless (ipv6_address.slice(0, @pref64n_prefix.size) <=> @pref64n_prefix) == 0
-        buffer.copy(ipv6_address, offset, 4, 12)
+      def translate_address_to_ipv4(source, source_offset, destination, destination_offset)
+        preflen = @pref64n_prefix.size
+        return unless (source.slice(source_offset, preflen) <=> @pref64n_prefix) == 0
+        destination.copy(source, destination_offset, 16 - preflen, source_offset + preflen)
 
         @negative_cs_delta
       end
 
-      def translate_address_to_ipv6(ipv4_address,buffer,offset = 0)
-        buffer.copy(@pref64n_prefix, offset, 12)
-        buffer.copy(ipv4_address, offset + 12, 4)
+      def translate_address_to_ipv6(source, source_offset, destination, destination_offset)
+        preflen = @pref64n_prefix.size
+        destination.copy(@pref64n_prefix, destination_offset, preflen)
+        destination.copy(source, destination_offset + preflen, 16 - preflen, source_offset)
 
         @cs_delta
       end

--- a/lib/xlat/rfc7915.rb
+++ b/lib/xlat/rfc7915.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'xlat/common'
+require 'xlat/protocols/ip'
 
 module Xlat
   # RFC 7915 based stateless IPv4/IPv6 translator (SIIT). Intentionally not thread-safe.
@@ -107,8 +108,8 @@ module Xlat
       new_header_buffer.set_value(:U8, 9, ipv6_proto)
 
       # Source and Destination address
-      cs_delta_a = @source_address_translator.translate_address_to_ipv4(ipv6_bytes.slice(ipv6_bytes_offset + 8,16), new_header_buffer, 12) or return return_buffer_ownership()
-      cs_delta_b = @destination_address_translator.translate_address_to_ipv4(ipv6_bytes.slice(ipv6_bytes_offset + 24,16), new_header_buffer, 16) or return return_buffer_ownership()
+      cs_delta_a = @source_address_translator.translate_address_to_ipv4(ipv6_bytes, ipv6_bytes_offset + 8, new_header_buffer, 12) or return return_buffer_ownership()
+      cs_delta_b = @destination_address_translator.translate_address_to_ipv4(ipv6_bytes, ipv6_bytes_offset + 24, new_header_buffer, 16) or return return_buffer_ownership()
       cs_delta += cs_delta_a + cs_delta_b
 
       # TODO: DF bit
@@ -220,8 +221,8 @@ module Xlat
       new_header_buffer.set_value(:U8, 7, ipv4_bytes.get_value(:U8, ipv4_bytes_offset + 8))
 
       # Source and Destination address
-      cs_delta_a = @destination_address_translator.translate_address_to_ipv6(ipv4_bytes.slice(ipv4_bytes_offset + 12,4), new_header_buffer, 8) or return return_buffer_ownership()
-      cs_delta_b = @source_address_translator.translate_address_to_ipv6(ipv4_bytes.slice(ipv4_bytes_offset + 16,4), new_header_buffer, 24) or return return_buffer_ownership()
+      cs_delta_a = @destination_address_translator.translate_address_to_ipv6(ipv4_bytes, ipv4_bytes_offset + 12, new_header_buffer, 8) or return return_buffer_ownership()
+      cs_delta_b = @source_address_translator.translate_address_to_ipv6(ipv4_bytes, ipv4_bytes_offset + 16, new_header_buffer, 24) or return return_buffer_ownership()
       cs_delta += cs_delta_a + cs_delta_b
 
       if ipv4_proto == 1

--- a/spec/address_translators/rfc6052_spec.rb
+++ b/spec/address_translators/rfc6052_spec.rb
@@ -11,21 +11,21 @@ RSpec.describe Xlat::AddressTranslators::Rfc6052 do
   describe "#translate_address_to_ipv4" do
     it "translates into ipv4" do
       buf = IO::Buffer.new(4)
-      expect(translator.translate_address_to_ipv4(IO::Buffer.for(IPAddr.new('64:ff9b::192.0.2.33').hton), buf)).to eq(0)
+      expect(translator.translate_address_to_ipv4(IO::Buffer.for(IPAddr.new('64:ff9b::192.0.2.33').hton), 0, buf, 0)).to eq(0)
       expect(buf.get_string).to eq(IPAddr.new('192.0.2.33').hton)
     end
 
     context "with invalid ipv6 address" do
       it "does nothing" do
         buf = IO::Buffer.for('')
-        expect(translator.translate_address_to_ipv4(IO::Buffer.for(IPAddr.new('2001:db8::192.0.2.33').hton), buf)).to eq(nil)
+        expect(translator.translate_address_to_ipv4(IO::Buffer.for(IPAddr.new('2001:db8::192.0.2.33').hton), 0, buf, 0)).to eq(nil)
       end
     end
 
     context "with offset" do
       it "writes translated address at specified offset" do
         buf = IO::Buffer.for("\xaf".b * 20).dup
-        expect(translator.translate_address_to_ipv4(IO::Buffer.for(IPAddr.new('64:ff9b::192.0.2.33').hton), buf, 4)).to eq(0)
+        expect(translator.translate_address_to_ipv4(IO::Buffer.for(IPAddr.new('64:ff9b::192.0.2.33').hton), 0, buf, 4)).to eq(0)
         expect(buf.size).to eq(20)
         expect(buf.get_string).to eq("\xaf".b * 4 + IPAddr.new('192.0.2.33').hton + "\xaf".b * 12)
       end
@@ -36,7 +36,7 @@ RSpec.describe Xlat::AddressTranslators::Rfc6052 do
 
       it "translates into ipv4" do
         buf = IO::Buffer.new(4)
-        expect(translator.translate_address_to_ipv4(IO::Buffer.for(IPAddr.new('2001:db8:64::192.0.2.33').hton), buf)).to eq(-11805)
+        expect(translator.translate_address_to_ipv4(IO::Buffer.for(IPAddr.new('2001:db8:64::192.0.2.33').hton), 0, buf, 0)).to eq(-11805)
         expect(buf.get_string).to eq(IPAddr.new('192.0.2.33').hton)
       end
     end
@@ -45,14 +45,14 @@ RSpec.describe Xlat::AddressTranslators::Rfc6052 do
   describe "#translate_address_to_ipv6" do
     it "translates into ipv6" do
       buf = IO::Buffer.new(16)
-      expect(translator.translate_address_to_ipv6(IO::Buffer.for(IPAddr.new('192.0.2.33').hton), buf)).to eq(0)
+      expect(translator.translate_address_to_ipv6(IO::Buffer.for(IPAddr.new('192.0.2.33').hton), 0, buf, 0)).to eq(0)
       expect(buf.get_string).to eq(IPAddr.new('64:ff9b::192.0.2.33').hton)
     end
 
     context "with offset" do
       it "writes translated address at specified offset" do
         buf = IO::Buffer.for("\xaf".b * 21).dup
-        expect(translator.translate_address_to_ipv6(IO::Buffer.for(IPAddr.new('192.0.2.33').hton), buf, 4)).to eq(0)
+        expect(translator.translate_address_to_ipv6(IO::Buffer.for(IPAddr.new('192.0.2.33').hton), 0, buf, 4)).to eq(0)
         expect(buf.size).to eq(21)
         expect(buf.get_string).to eq("\xaf".b * 4 + IPAddr.new('64:ff9b::192.0.2.33').hton + "\xaf".b)
       end
@@ -63,7 +63,7 @@ RSpec.describe Xlat::AddressTranslators::Rfc6052 do
 
       it "translates into ipv4" do
         buf = IO::Buffer.new(16)
-        expect(translator.translate_address_to_ipv6(IO::Buffer.for(IPAddr.new('192.0.2.33').hton), buf)).to eq(11805)
+        expect(translator.translate_address_to_ipv6(IO::Buffer.for(IPAddr.new('192.0.2.33').hton), 0, buf, 0)).to eq(11805)
         expect(buf.get_string).to eq(IPAddr.new('2001:db8:64::192.0.2.33').hton)
       end
     end

--- a/spec/rfc7915_spec.rb
+++ b/spec/rfc7915_spec.rb
@@ -7,36 +7,36 @@ require_relative 'test_packets'
 
 RSpec.describe Xlat::Rfc7915 do
   module MockAddrTranslator
-    def self.translate_address_to_ipv4(ipv6_address,buffer,offset = 0)
-      case IPAddr.new_ntoh(ipv6_address.get_string).to_s
+    def self.translate_address_to_ipv4(source, source_offset, destination, destination_offset)
+      case IPAddr.new_ntoh(source.get_string(source_offset, 16)).to_s
       when IPAddr.new('64:ff9b:1:fffe::192.0.2.2').to_s
-        buffer.copy(IO::Buffer.for(IPAddr.new('192.0.2.2').hton), offset)
+        destination.copy(IO::Buffer.for(IPAddr.new('192.0.2.2').hton), destination_offset)
         0
       when IPAddr.new('64:ff9b::192.0.2.3').to_s
-        buffer.copy(IO::Buffer.for(IPAddr.new('192.0.2.3').hton), offset)
+        destination.copy(IO::Buffer.for(IPAddr.new('192.0.2.3').hton), destination_offset)
         0
       when IPAddr.new('2001:db8:60::192.0.2.7').to_s
-        buffer.copy(IO::Buffer.for(IPAddr.new('192.0.2.7').hton), offset)
+        destination.copy(IO::Buffer.for(IPAddr.new('192.0.2.7').hton), destination_offset)
         -(0x2001 + 0x0db8 + 0x0060)
       when IPAddr.new('2001:db8:64::192.0.2.8').to_s
-        buffer.copy(IO::Buffer.for(IPAddr.new('192.0.2.8').hton), offset)
+        destination.copy(IO::Buffer.for(IPAddr.new('192.0.2.8').hton), destination_offset)
         -(0x2001 + 0x0db8 + 0x0064)
       end
     end
 
-    def self.translate_address_to_ipv6(ipv4_address,buffer,offset = 0)
-      case IPAddr.new_ntoh(ipv4_address.get_string).to_s
+    def self.translate_address_to_ipv6(source, source_offset, destination, destination_offset)
+      case IPAddr.new_ntoh(source.get_string(source_offset, 4)).to_s
       when '192.0.2.2'
-        buffer.copy(IO::Buffer.for(IPAddr.new('64:ff9b:1:fffe::192.0.2.2').hton), offset)
+        destination.copy(IO::Buffer.for(IPAddr.new('64:ff9b:1:fffe::192.0.2.2').hton), destination_offset)
         0
       when '192.0.2.3'
-        buffer.copy(IO::Buffer.for(IPAddr.new('64:ff9b::192.0.2.3').hton), offset)
+        destination.copy(IO::Buffer.for(IPAddr.new('64:ff9b::192.0.2.3').hton), destination_offset)
         0
       when '192.0.2.7'
-        buffer.copy(IO::Buffer.for(IPAddr.new('2001:db8:60::192.0.2.7').hton), offset)
+        destination.copy(IO::Buffer.for(IPAddr.new('2001:db8:60::192.0.2.7').hton), destination_offset)
         (0x2001 + 0x0db8 + 0x0060)
       when '192.0.2.8'
-        buffer.copy(IO::Buffer.for(IPAddr.new('2001:db8:64::192.0.2.8').hton), offset)
+        destination.copy(IO::Buffer.for(IPAddr.new('2001:db8:64::192.0.2.8').hton), destination_offset)
         (0x2001 + 0x0db8 + 0x0064)
       end
     end


### PR DESCRIPTION
This patch modifies the AddressTranslation interface to accept source and destination buffers with explicit offsets, eliminating the need for intermediate buffer allocations at the caller side.

```
ruby 3.4.5 (2025-07-16 revision 20cda200d3) +YJIT +PRISM [x86_64-linux]
Warming up --------------------------------------
    main: UDP 6-to-4    32.584k i/100ms
Calculating -------------------------------------
    main: UDP 6-to-4    323.817k (± 1.8%) i/s    (3.09 μs/i) -      3.258M in  10.065832s

Comparison:
 patched: UDP 6-to-4:   365544.5 i/s
    main: UDP 6-to-4:   323816.7 i/s - 1.13x  slower

ruby 3.4.5 (2025-07-16 revision 20cda200d3) +YJIT +PRISM [x86_64-linux]
Warming up --------------------------------------
    main: UDP 4-to-6    51.787k i/100ms
Calculating -------------------------------------
    main: UDP 4-to-6    529.921k (± 1.1%) i/s    (1.89 μs/i) -      5.334M in  10.066969s

Comparison:
 patched: UDP 4-to-6:   577352.3 i/s
    main: UDP 4-to-6:   529920.7 i/s - 1.09x  slower

ruby 3.4.5 (2025-07-16 revision 20cda200d3) +YJIT +PRISM [x86_64-linux]
Warming up --------------------------------------
    main: TCP 6-to-4    34.825k i/100ms
Calculating -------------------------------------
    main: TCP 6-to-4    345.936k (± 2.5%) i/s    (2.89 μs/i) -      3.482M in  10.073507s

Comparison:
 patched: TCP 6-to-4:   358844.9 i/s
    main: TCP 6-to-4:   345935.5 i/s - same-ish: difference falls within error

ruby 3.4.5 (2025-07-16 revision 20cda200d3) +YJIT +PRISM [x86_64-linux]
Warming up --------------------------------------
    main: TCP 4-to-6    52.893k i/100ms
Calculating -------------------------------------
    main: TCP 4-to-6    533.078k (± 1.8%) i/s    (1.88 μs/i) -      5.342M in  10.024930s

Comparison:
 patched: TCP 4-to-6:   577846.9 i/s
    main: TCP 4-to-6:   533078.5 i/s - 1.08x  slower

ruby 3.4.5 (2025-07-16 revision 20cda200d3) +YJIT +PRISM [x86_64-linux]
Warming up --------------------------------------
main: ICMP echo 6-to-4
                        23.023k i/100ms
Calculating -------------------------------------
main: ICMP echo 6-to-4
                        229.563k (± 0.9%) i/s    (4.36 μs/i) -      2.302M in  10.029839s

Comparison:
patched: ICMP echo 6-to-4:   233499.0 i/s
main: ICMP echo 6-to-4:   229563.4 i/s - same-ish: difference falls within error

ruby 3.4.5 (2025-07-16 revision 20cda200d3) +YJIT +PRISM [x86_64-linux]
Warming up --------------------------------------
main: ICMP echo 4-to-6
                        28.870k i/100ms
Calculating -------------------------------------
main: ICMP echo 4-to-6
                        285.234k (± 1.9%) i/s    (3.51 μs/i) -      2.858M in  10.024055s

Comparison:
patched: ICMP echo 4-to-6:   300690.0 i/s
main: ICMP echo 4-to-6:   285234.3 i/s - 1.05x  slower
```